### PR TITLE
chore: update strands-single-agent dependencies to latest versions

### DIFF
--- a/patterns/strands-single-agent/requirements.txt
+++ b/patterns/strands-single-agent/requirements.txt
@@ -1,4 +1,4 @@
 # Strands agent dependencies with pinned versions
-strands-agents==1.16.0
-mcp==1.23.1
-bedrock-agentcore[strands-agents]==1.0.6
+strands-agents==1.24.0
+mcp==1.26.0
+bedrock-agentcore[strands-agents]==1.2.0


### PR DESCRIPTION
Updates Python dependencies for the strands-single-agent pattern:
Package | Old | New
-- | -- | --
strands-agents | 1.16.0 | 1.24.0
mcp | 1.23.1 | 1.26.0
bedrock-agentcore | 1.0.6 | 1.2.0

