### PR TITLE
fix: prevent repo-stats workflow from failing on forks

### DIFF
--- a/.github/workflows/repo-stats.yml
+++ b/.github/workflows/repo-stats.yml
@@ -13,6 +13,7 @@ on:
 jobs:
     collect-stats:
         name: collect-repo-stats
+        if: github.repository == 'awslabs/fullstack-solution-template-for-agentcore'
         runs-on: ubuntu-latest
         steps:
             - name: run-ghrs


### PR DESCRIPTION
Why
-----
When someone forks this repo, the scheduled github-repo-stats workflow
runs but fails because the fork doesn't have the GHRS_GITHUB_API_TOKEN
secret configured. This creates noisy, unnecessary failure notifications
for fork owners. And, more importantly, forks don't need to keep track
of stats

How
-----
Added a repository condition (`if: github.repository == 'awslabs/...'`)
to the collect-stats job so it only executes on the upstream repo and
is silently skipped on forks.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
