### PR TITLE
Add Dependabot auto-merge and PR labeler workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,39 @@
+frontend:
+  - changed-files:
+      - any-glob-to-any-file: "frontend/**"
+
+infrastructure:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "infra-cdk/**"
+          - "infra-terraform/**"
+
+backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "gateway/**"
+          - "patterns/**"
+          - "tools/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ".github/**"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"
+          - "test-scripts/**"
+          - "**/*.test.*"
+
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docker/**"
+          - "**/Dockerfile*"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-approve patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,14 @@
+name: Labeler
+
+on: [pull_request_target]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- **dependabot.yml**: Auto-approve and auto-merge patch/minor dependency updates via Dependabot. Major version bumps require manual review. Upgraded from pinned commit hash to `dependabot/fetch-metadata@v2`. Removed unused `issues: write` permission, added `contents: write` for merge.
- **label.yml**: Upgraded `actions/labeler` from v4 to v5. Auto-labels PRs based on changed file paths.
- **labeler.yml** (new): Label rules mapping file paths to labels:
  - `frontend` — `frontend/**`
  - `infrastructure` — `infra-cdk/**`, `infra-terraform/**`
  - `backend` — `gateway/**`, `patterns/**`, `tools/**`
  - `documentation` — `docs/**`, `**/*.md`
  - `ci` — `.github/**`
  - `tests` — `tests/**`, `test-scripts/**`, `**/*.test.*`
  - `docker` — `docker/**`, `**/Dockerfile*`
