### PR TITLE
fix(ci): pin tj-actions/changed-files to SHA and bump Node to 20

### DIFF
--- a/.github/workflows/ash-security-scan.yml
+++ b/.github/workflows/ash-security-scan.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             **/*.py

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get changed JS/TS files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             frontend/**/*.js
@@ -34,7 +34,7 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get changed Python files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             **/*.py


### PR DESCRIPTION
## Summary
- **Pin `tj-actions/changed-files` to commit SHA** (`ed68ef82c095e0d48ec87eccea555d944a631a4c`) in 3 workflows (`js-lint`, `python-lint`, `ash-security-scan`) to prevent supply chain attacks if the `v46` tag is moved
- **Bump Node.js from 18 to 20** in `js-lint.yml` — Node 18 reached EOL in April 2025

## Test plan
- [x] Verify `js-lint` workflow runs successfully on a PR with JS/TS changes
- [x] Verify `python-lint` workflow runs successfully on a PR with Python changes
- [x] Verify `ash-security-scan` workflow runs successfully on a PR with relevant file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)