### PR TITLE
Documentation Update: Need X-Ray VPC endpoint for private VPC deployment mode

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -117,6 +117,7 @@ When deploying in VPC mode, the runtime runs in private subnets without internet
 | `com.amazonaws.{region}.ecr.dkr` | ECR Docker (Docker deployment) | Interface |
 | `com.amazonaws.{region}.s3` | S3 (ZIP deployment, ECR layers) | Gateway |
 | `com.amazonaws.{region}.dynamodb` | DynamoDB (feedback table) | Gateway |
+| `com.amazonaws.{region}.xray` | X-Ray (OTel trace export) | Interface |
 
 Replace `{region}` with your deployment region (e.g. `us-east-1`).
 


### PR DESCRIPTION
**Description of changes:**
This PR updates the deployment documentation for deployments in private VPC mode where AgentCore Runtime runs in private subnets without internet access. The OpenTelemetry instrumentation (aws-opentelemetry-distro) is configured on all agent patterns and exports traces to AWS X-Ray. Without the `com.amazonaws.{region}.xray` VPC interface endpoint reachable from the runtime's subnets, trace export silently fails — the BatchSpanProcessor retries every 5 seconds and never succeeds.


