### PR TITLE
fix: updated OpenTelemetry distro version 

### DIFF
--- a/patterns/claude-agent-sdk-multi-agent/Dockerfile
+++ b/patterns/claude-agent-sdk-multi-agent/Dockerfile
@@ -30,7 +30,7 @@ COPY tools/ tools/
 # Copy and install agent-specific requirements
 COPY patterns/claude-agent-sdk-multi-agent/requirements.txt requirements.txt
 RUN uv pip install --no-cache -r requirements.txt && \
-    uv pip install --no-cache aws-opentelemetry-distro==0.10.1
+    uv pip install --no-cache aws-opentelemetry-distro==0.16.0
 
 # Install FAST package with only core dependencies
 RUN uv pip install --no-cache -e . --no-deps && \

--- a/patterns/claude-agent-sdk-single-agent/Dockerfile
+++ b/patterns/claude-agent-sdk-single-agent/Dockerfile
@@ -30,7 +30,7 @@ COPY tools/ tools/
 # Copy and install agent-specific requirements
 COPY patterns/claude-agent-sdk-single-agent/requirements.txt requirements.txt
 RUN uv pip install --no-cache -r requirements.txt && \
-    uv pip install --no-cache aws-opentelemetry-distro==0.10.1
+    uv pip install --no-cache aws-opentelemetry-distro==0.16.0
 
 # Install FAST package with only core dependencies
 RUN uv pip install --no-cache -e . --no-deps && \

--- a/patterns/langgraph-single-agent/Dockerfile
+++ b/patterns/langgraph-single-agent/Dockerfile
@@ -19,7 +19,7 @@ COPY gateway/ gateway/
 # Copy and install agent-specific requirements first
 COPY patterns/langgraph-single-agent/requirements.txt requirements.txt
 RUN uv pip install --no-cache -r requirements.txt && \
-    uv pip install --no-cache aws-opentelemetry-distro==0.10.1
+    uv pip install --no-cache aws-opentelemetry-distro==0.16.0
 
 # Install FAST package with only core dependencies (no dev/agent optional deps)
 RUN uv pip install --no-cache -e . --no-deps && \

--- a/patterns/strands-single-agent/Dockerfile
+++ b/patterns/strands-single-agent/Dockerfile
@@ -20,7 +20,7 @@ COPY tools/ tools/
 # Copy and install agent-specific requirements first
 COPY patterns/strands-single-agent/requirements.txt requirements.txt
 RUN uv pip install --no-cache -r requirements.txt && \
-    uv pip install --no-cache aws-opentelemetry-distro==0.10.1
+    uv pip install --no-cache aws-opentelemetry-distro==0.16.0
 
 # Install FAST package with only core dependencies (no dev/agent optional deps)
 RUN uv pip install --no-cache -e . --no-deps && \


### PR DESCRIPTION
**Update OpenTelemetry distro version to 0.16.0**


This PR updates the aws-opentelemetry-distro version from 0.10.1 to 0.16.0.


**Problem**
The previous Dockerfile was pinned to version 0.10.1, which is incompatible with AgentCore evaluations and was causing errors (see image below).  While the [AgentCore documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html) recommends using `>=`0.10.0, this PR pins to an exact version (==0.16.0) rather than using >= to ensure reproducible Docker builds.
  
<img width="661" height="134" alt="Screenshot 2026-03-19 at 3 04 41 PM" src="https://github.com/user-attachments/assets/e80241c5-2def-4767-9c63-c042df0c511e" />
  
  
**Solution**

Bumping aws-opentelemetry-distro==0.16.0 resolves the incompatibility and fixes the reported error.