### PR TITLE
fix: enable API Gateway cache encryption at rest

### DIFF
--- a/infra-cdk/lib/backend-stack.ts
+++ b/infra-cdk/lib/backend-stack.ts
@@ -551,6 +551,7 @@ export class BackendStack extends cdk.NestedStack {
         throttlingRateLimit: 100,
         throttlingBurstLimit: 200,
         cachingEnabled: true,
+        cacheDataEncrypted: true,
         cacheClusterEnabled: true,
         cacheClusterSize: "0.5",
         cacheTtl: cdk.Duration.minutes(5),

--- a/infra-terraform/modules/backend/feedback.tf
+++ b/infra-terraform/modules/backend/feedback.tf
@@ -384,6 +384,7 @@ resource "aws_api_gateway_method_settings" "all" {
     throttling_rate_limit  = local.api_throttling_rate_limit
     throttling_burst_limit = local.api_throttling_burst_limit
     caching_enabled        = true
+    cache_data_encrypted   = true
     cache_ttl_in_seconds   = local.api_cache_ttl_seconds
     logging_level          = "INFO"
     metrics_enabled        = true


### PR DESCRIPTION
Adds cache_data_encrypted/cacheDataEncrypted to both Terraform and CDK API Gateway method settings. Resolves KICS critical finding for unencrypted API Gateway cache.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
