### PR TITLE
feat: UUID-based identity mapping, IAM permission fixes, policy name fix

### DIFF
--- a/docs/CEDAR_POLICY_GUIDE.md
+++ b/docs/CEDAR_POLICY_GUIDE.md
@@ -14,7 +14,7 @@ Custom claims are injected by the V3 Pre-Token Lambda via `claimsToAddOrOverride
 
 | Claim | Purpose | Example Value |
 |-------|---------|---------------|
-| `user_id` | Authenticated user's identity | `"yourname@company.com"` |
+| `user_id` | Authenticated user's identity | `"<cognito-sub-uuid>"` |
 | `department` | User's organizational unit | `"finance"` |
 | `role` | User's permission level | `"admin"` |
 
@@ -287,7 +287,7 @@ when {
   principal.hasTag("department")
 };
 
-// But explicitly block a specific user
+// But explicitly block a specific user (by their Cognito sub UUID)
 forbid(
   principal is AgentCore::OAuthUser,
   action == AgentCore::Action::"sample-tool-target___text_analysis_tool",
@@ -295,13 +295,13 @@ forbid(
 )
 when {
   principal.hasTag("user_id") &&
-  principal.getTag("user_id") == "compromised-user@example.com"
+  principal.getTag("user_id") == "<compromised-user-sub-uuid>"
 };
 ```
 
 **Result:**
 - Any user with a department → permitted
-- `compromised-user@example.com` → denied (forbid wins over permit)
+- The user matching `<compromised-user-sub-uuid>` → denied (forbid wins over permit)
 
 > **Note:** Cedar's deny-by-default means simply omitting a user/department from the `permit`
 > is often sufficient to deny access. Use `forbid` when overriding a broad `permit`
@@ -312,7 +312,7 @@ when {
 
 ### Capability 4: Wildcard String Matching (`like`)
 
-**Scenario:** Only users with an `@example.com` email domain can access internal tools. External contractors with other email domains are denied.
+**Scenario:** Only users with an internal email domain can access internal tools. This requires injecting an `email` claim via the Pre-Token Lambda (not included in the default demo, but straightforward to add).
 
 **How it works:** Use `like` with `*` wildcard for pattern matching on string claim values.
 
@@ -323,19 +323,17 @@ permit(
   resource == AgentCore::Gateway::"{{GATEWAY_ARN}}"
 )
 when {
-  principal.hasTag("user_id") &&
-  principal.getTag("user_id") like "*@example.com"
+  principal.hasTag("email") &&
+  principal.getTag("email") like "*@example.com"
 };
 ```
 
 **Result:**
-- `alice@example.com` → permitted
-- `bob@example.com` → permitted
-- `contractor@external.com` → denied (doesn't match pattern)
+- User with `email` claim `alice@example.com` → permitted
+- User with `email` claim `bob@example.com` → permitted
+- User with `email` claim `contractor@external.com` → denied (doesn't match pattern)
 
-> **Note:** `like` only supports `*` as a wildcard, which matches zero or more characters
-> of any kind (letters, numbers, symbols, dots, etc.). It does not support regex,
-> single-character wildcards, character classes, or other pattern syntax.
+> **Note:** This example uses a custom `email` claim (injected by the Pre-Token Lambda via `claimsToAddOrOverride`). The default `user_id` claim is a UUID and would not match email patterns. The `like` operator only supports `*` as a wildcard, which matches zero or more characters of any kind (letters, numbers, symbols, dots, etc.). It does not support regex, single-character wildcards, character classes, or other pattern syntax.
 
 ---
 

--- a/docs/IDENTITY_POLICY.md
+++ b/docs/IDENTITY_POLICY.md
@@ -49,7 +49,7 @@ The identity propagation flow has six steps:
 1. User logs in → Frontend gets JWT from Cognito
 2. Frontend sends request → Runtime validates JWT, extracts user_id (sub claim)
 3. Runtime calls Cognito /oauth2/token with aws_client_metadata containing user_id
-4. Cognito V3 Pre-Token Lambda fires → reads user_id → injects department/role claims into M2M token
+4. Cognito V3 Pre-Token Lambda fires → reads user_id (UUID) → looks up department/role from UUID mapping → injects claims into M2M token
 5. Runtime calls Gateway tool with the enriched M2M token
 6. Gateway's CUSTOM_JWT Authorizer maps token claims to Cedar principal tags → Policy Engine evaluates Cedar policy → allow or deny
 ```
@@ -70,22 +70,33 @@ The Cognito User Pool is configured with `featurePlan: ESSENTIALS`. This is requ
 
 This Lambda fires on every token generation event (both user login and M2M). It only processes M2M flows (`TokenGeneration_ClientCredentials`) and skips user login flows.
 
-For M2M flows, it reads `verified_user_id` from `clientMetadata` and assigns department/role claims based on the user's identity:
+For M2M flows, it reads `verified_user_id` (the Cognito `sub` — a UUID) from `clientMetadata` and assigns department/role claims based on a UUID-to-group mapping:
 
-| User Email Contains | Department | Role |
-|---------------------|------------|------|
-| `fastprojectadmin` | finance | admin |
-| `fastuser` | engineering | developer |
-| (anything else, including the email registered in config.yaml) | guest | viewer |
+| User Sub (UUID) | Department | Role |
+|-----------------|------------|------|
+| `<fastprojectadmin-user-sub-uuid>` | finance | admin |
+| `<fastuser-user-sub-uuid>` | engineering | developer |
+| (any UUID not in the map) | guest | viewer |
+
+> **Note:** The Cognito `sub` is an immutable, unique UUID assigned to each user at creation time — a recommended identifier for authorization decisions.
+
+**Setup (two-step deployment):**
+1. Deploy the stack once — all users are assigned `guest/viewer` by default
+2. Look up user UUIDs: `aws cognito-idp list-users --user-pool-id <pool-id>`
+3. Replace the placeholder UUIDs in `USER_ROLE_MAP` with actual user subs
+4. Redeploy (`cdk deploy`) to apply the updated mapping
+
+**Alternative (email-based matching without two-step deploy):**
+To avoid the UUID lookup step, the Lambda can resolve the user's email from the sub via the Cognito `ListUsers` API and match against email substrings (e.g., `"fastprojectadmin" in email`). This requires adding `cognito-idp:ListUsers` permission to the Pre-Token Lambda role. UUID-based mapping is recommended because UUIDs are immutable and not PII. See the [Changing Group Assignment](#changing-group-assignment) section for details.
+
+**Dynamic group assignment:** Replace the hardcoded `USER_ROLE_MAP` with a DynamoDB table keyed by the user's sub (UUID), a directory service query, or other identity provider.
 
 These claims are injected into the M2M access token via `claimsToAddOrOverride`:
-- `user_id` — the authenticated user's ID
+- `user_id` — the authenticated user's Cognito sub (UUID)
 - `department` — the user's department
 - `role` — the user's role
 
-> **Note:** These claim names (`user_id`, `department`, `role`) are custom, application-defined claims — not standard JWT/OIDC claims. You can define any claim names you need. See [Understanding Claims](CEDAR_POLICY_GUIDE.md#understanding-claims-custom-vs-standard) for details.
-
-To use dynamic group assignment, replace the hardcoded logic in the Pre-Token Lambda with a DynamoDB lookup, directory service query, or other identity provider.
+> **Note:** These claim names (`user_id`, `department`, `role`) are custom, application-defined claims — not standard JWT/OIDC claims. Custom claim names are defined based on the application's access control needs. See [Understanding Claims](CEDAR_POLICY_GUIDE.md#understanding-claims-custom-vs-standard) for details.
 
 ### Cedar Policy File
 
@@ -192,11 +203,11 @@ Each pattern's `tools/gateway.py` contains both approaches with switching instru
 
 ### Changing Group Assignment
 
-Edit `infra-cdk/lambdas/pretoken-v3/index.py` to replace the hardcoded email-based logic with your own identity resolution. For example:
+Edit `infra-cdk/lambdas/pretoken-v3/index.py` to replace the `USER_ROLE_MAP` with your own identity resolution. Options:
 
-- Query a DynamoDB table mapping user IDs to departments
-- Call an external directory service (LDAP, Active Directory)
-- Call the Cognito API (`AdminGetUser`) to read user attributes or group membership for the `user_id` received in `clientMetadata`
+- **DynamoDB table (dynamic mapping):** Create a table with the user's `sub` (UUID) as the partition key and `department`/`role` as attributes. The Lambda queries the table using the `verified_user_id` received in `clientMetadata`. This avoids redeployment when group assignments change.
+- **Cognito ListUsers (email-based):** Resolve the user's email from the sub via `cognito-idp:ListUsers`, and match against email substrings. Avoids two-step deployment but requires adding `cognito-idp:ListUsers` permission to the Pre-Token Lambda role.
+- **External directory service:** Call LDAP, Active Directory, or another identity provider using the UUID as the lookup key.
 
 ### Adding New Claims
 
@@ -300,14 +311,16 @@ def lambda_handler(event, context):
 
     # Existing user identity logic (unchanged)
     meta = event["request"].get("clientMetadata", {})
-    user_id = meta.get("verified_user_id", "")
+    user_id = meta.get("verified_user_id", "")  # Cognito sub (UUID)
 
-    if "fastprojectadmin" in user_id.lower():
-        department, role = "finance", "admin"
-    elif "fastuser" in user_id.lower():
-        department, role = "engineering", "developer"
-    else:
-        department, role = "guest", "viewer"
+    # UUID-based group mapping (see USER_ROLE_MAP in pretoken-v3/index.py)
+    user_role_map = {
+        "<fastprojectadmin-sub-uuid>": {"department": "finance", "role": "admin"},
+        "<fastuser-sub-uuid>": {"department": "engineering", "role": "developer"},
+    }
+    default_group = {"department": "guest", "role": "viewer"}
+    group = user_role_map.get(user_id, default_group)
+    department, role = group["department"], group["role"]
 
     event["response"]["claimsAndScopeOverrideDetails"] = {
         "accessTokenGeneration": {

--- a/docs/REPLACING_COGNITO.md
+++ b/docs/REPLACING_COGNITO.md
@@ -95,7 +95,7 @@ User JWT → Runtime (validates user JWT via any IdP's OIDC)
   → Runtime gets a plain M2M token from IdP (no user claims needed)
   → Runtime sends to Gateway:
     - Authorization: Bearer <M2M_token>        ← proves machine trust
-    - X-User-Id: alice@company.com             ← carries user identity (plain string)
+    - X-User-Id: <user-sub-uuid>               ← carries user identity (plain string)
   → Gateway authorizer validates M2M token only (machine trust)
   → Request Interceptor Lambda fires:
     - Reads X-User-Id from custom header
@@ -582,7 +582,7 @@ Since the Gateway receives M2M tokens in the current architecture, Cedar Policy 
 ```
 User Auth Token (has groups):     M2M Token (NO groups):
 {                                 {
-  "sub": "alice",                   "sub": "machine-client-id",
+  "sub": "<user-sub-uuid>",                   "sub": "machine-client-id",
   "cognito:groups": [               "scope": "gateway/read gateway/write",
     "finance",                      "token_use": "access"
     "admin"                         // No user context!
@@ -594,7 +594,7 @@ User Auth Token (has groups):     M2M Token (NO groups):
 
 The Pre-Token Lambda can call the Cognito `AdminListGroupsForUser` API to fetch the user's actual group memberships and inject them as custom claims in the M2M token.
 
-This replaces the hardcoded demo mapping (where `fastprojectadmin` → finance/admin) with real, dynamic group-based logic.
+This replaces the hardcoded demo mapping (UUID-to-group map) with real, dynamic group-based logic.
 
 ```python
 import boto3
@@ -622,8 +622,11 @@ def lambda_handler(event, context):
         logger.warning("No verified_user_id in clientMetadata")
         return event
     
-    # --- REPLACES HARDCODED MAPPING ---
-    # Fetch user's ACTUAL Cognito groups
+    # --- REPLACES UUID-BASED USER_ROLE_MAP ---
+    # Fetch user's ACTUAL Cognito groups.
+    # Note: verified_user_id is the Cognito sub (UUID). AdminListGroupsForUser
+    # requires the Cognito username (which is the email in FAST). Resolve the
+    # UUID to username via ListUsers first, then call AdminListGroupsForUser.
     user_groups = get_user_groups(verified_user_id)
     
     # Determine department and role from groups
@@ -645,16 +648,31 @@ def lambda_handler(event, context):
     return event
 
 
-def get_user_groups(username):
-    """Fetch user's Cognito groups via Admin API."""
+def get_user_groups(user_id):
+    """Fetch user's Cognito groups via Admin API.
+
+    Note: AdminListGroupsForUser requires the Cognito username, not the sub.
+    In FAST, the username is the user's email. The sub (UUID) must be resolved
+    to the username via ListUsers before calling AdminListGroupsForUser.
+    """
     try:
+        # Resolve UUID to username (AdminListGroupsForUser requires username)
+        users = cognito.list_users(
+            UserPoolId=USER_POOL_ID,
+            Filter=f'sub = "{user_id}"',
+            Limit=1,
+        )
+        if not users.get("Users"):
+            return []
+        username = users["Users"][0]["Username"]
+
         response = cognito.admin_list_groups_for_user(
             UserPoolId=USER_POOL_ID,
             Username=username,
         )
         return [group['GroupName'] for group in response.get('Groups', [])]
     except Exception as e:
-        logger.error("Failed to fetch groups for user %s: %s", username, str(e))
+        logger.error("Failed to fetch groups for user %s: %s", user_id, str(e))
         return []
 
 

--- a/infra-cdk/lambdas/pretoken-v3/index.py
+++ b/infra-cdk/lambdas/pretoken-v3/index.py
@@ -37,7 +37,6 @@ To use dynamic group assignment, replace the hardcoded mapping below with a
 DynamoDB table keyed by the user's sub (UUID). See docs/IDENTITY_POLICY.md.
 """
 
-
 # ============================================================================
 # USER-TO-GROUP MAPPING
 # ============================================================================

--- a/infra-cdk/lambdas/pretoken-v3/index.py
+++ b/infra-cdk/lambdas/pretoken-v3/index.py
@@ -7,7 +7,7 @@ Only M2M flows (Client Credentials grant) are processed; user login flows
 are passed through unchanged.
 
 Custom claims injected (application-defined, not standard JWT/OIDC claims):
-  - user_id:    The authenticated user's ID (e.g., "yourname@company.com")
+  - user_id:    The authenticated user's Cognito sub (a UUID)
   - department: The user's department (e.g., "finance")
   - role:       The user's role (e.g., "admin")
 
@@ -15,23 +15,49 @@ These claim names are arbitrary — you can define any names you need.
 Just ensure the names match between this Lambda's output and the Cedar
 policy's principal.getTag() references.
 
-The verified_user_id is read from clientMetadata, which is passed via the
-aws_client_metadata parameter in the direct Cognito /oauth2/token call
-(see patterns/utils/auth.py — get_gateway_access_token).
+The verified_user_id (Cognito sub) is read from clientMetadata, which is
+passed via the aws_client_metadata parameter in the direct Cognito
+/oauth2/token call (see patterns/utils/auth.py — get_gateway_access_token).
+The Cognito sub is an opaque, immutable UUID assigned to each user at
+creation time (e.g., "a1b2c3d4-5678-90ab-cdef-1234567890ab").
+See docs/IDENTITY_POLICY.md for setup instructions.
 
-Group assignment is hardcoded for demo purposes:
-  - fastprojectadmin@* → department: "finance", role: "admin"
-  - fastuser@*         → department: "engineering", role: "developer"
-  - others (including the email registered in config.yaml) → department: "guest", role: "viewer"
+GROUP ASSIGNMENT SETUP (two-step deployment):
+  1. Deploy the stack once (all users will be assigned "guest/viewer")
+  2. Look up user UUIDs: aws cognito-idp list-users --user-pool-id <pool-id>
+  3. Replace the placeholder UUIDs below with actual user subs
+  4. Redeploy (cdk deploy) to apply the updated mapping
 
-The user registered via config.yaml will be assigned "guest/viewer"
-by default. To customize, replace the hardcoded logic with a DynamoDB
-lookup, directory service query, or other identity provider. Update the
-Cedar policy (gateway/policies/policy.cedar) to match the new claim values.
+ALTERNATIVE (email-based matching without two-step deploy):
+  If you prefer email-based matching that works on first deploy without
+  UUID lookup, see docs/IDENTITY_POLICY.md for instructions on adding
+  email resolution via Cognito ListUsers API in this Lambda.
 
-To use dynamic group assignment, replace the hardcoded logic with a
-DynamoDB lookup, directory service query, or other identity provider.
+To use dynamic group assignment, replace the hardcoded mapping below with a
+DynamoDB table keyed by the user's sub (UUID). See docs/IDENTITY_POLICY.md.
 """
+
+
+# ============================================================================
+# USER-TO-GROUP MAPPING
+# ============================================================================
+# Replace the placeholder UUIDs below with actual Cognito user subs after
+# first deploy. Run: aws cognito-idp list-users --user-pool-id <pool-id>
+# The sub is found in each user's Attributes list under Name="sub".
+#
+# Format: "<cognito-sub-uuid>": {"department": "...", "role": "..."}
+#
+# The UUID must be wrapped in quotes as a string key.
+# ============================================================================
+USER_ROLE_MAP = {
+    "<fastprojectadmin-user-sub-uuid>": {"department": "finance", "role": "admin"},
+    "<fastuser-user-sub-uuid>": {"department": "engineering", "role": "developer"},
+}
+
+# Default assignment when user is not in the map.
+# With Cedar policy V1: guest is permitted.
+# With Cedar policy V2: guest is denied (gateway target tool hidden from agent).
+DEFAULT_GROUP = {"department": "guest", "role": "viewer"}
 
 
 def lambda_handler(event: dict, context: dict) -> dict:
@@ -52,46 +78,27 @@ def lambda_handler(event: dict, context: dict) -> dict:
         print("[PRE-TOKEN] Not a Client Credentials flow - skipping")
         return event
 
-    # Get verified user_id from clientMetadata
-    # This is passed via aws_client_metadata in the direct Cognito /oauth2/token call
+    # Read the verified user_id (Cognito sub / UUID) from clientMetadata.
+    # This is passed via aws_client_metadata in the direct Cognito /oauth2/token call.
     meta = event["request"].get("clientMetadata", {})
     user_id = meta.get("verified_user_id", "")
 
-    if user_id:
-        print("[PRE-TOKEN] Processing M2M token - verified_user_id received")
-    else:
-        print("[PRE-TOKEN] Processing M2M token - no verified_user_id in metadata")
+    if not user_id:
+        print("[PRE-TOKEN] No verified_user_id in metadata")
+        return event
 
-    # Demo identity assignment for Cedar policy evaluation.
-    # Replace this logic with a DynamoDB lookup, directory service query,
-    # or other identity provider for real deployments.
-    #
-    # The Cedar policy (gateway/policies/policy.cedar) has two versions:
-    #   V1: permits all departments including "guest"
-    #   V2: permits only "finance" and "engineering" (guest is denied)
-    #
-    # To test different access levels, change the assignment logic below
-    # and update the Cedar policy to match.
-    if "fastprojectadmin" in user_id.lower():
-        department = "finance"
-        role = "admin"
-        print("[PRE-TOKEN] Assigned: department=finance, role=admin")
-    elif "fastuser" in user_id.lower():
-        department = "engineering"
-        role = "developer"
-        print("[PRE-TOKEN] Assigned: department=engineering, role=developer")
-    else:
-        # Default assignment for all other users.
-        # See gateway/policies/policy.cedar (V1 vs V2) to determine
-        # whether "guest" is permitted or denied.
-        department = "guest"
-        role = "viewer"
-        print("[PRE-TOKEN] Assigned: department=guest, role=viewer")
+    print("[PRE-TOKEN] Processing M2M token - verified_user_id received")
+
+    # Look up department/role from the UUID mapping.
+    # If the user's sub is not in the map, they get the default group (guest/viewer).
+    # To assign yourself to a non-default group, replace the placeholder UUIDs
+    # above with your actual Cognito sub. See docs/IDENTITY_POLICY.md.
+    group = USER_ROLE_MAP.get(user_id, DEFAULT_GROUP)
+    department = group["department"]
+    role = group["role"]
+    print(f"[PRE-TOKEN] Assigned: department={department}, role={role}")
 
     # Inject CUSTOM claims into the M2M Access Token.
-    # These are application-defined claims
-    # added via Cognito V3 Pre-Token Generation trigger (claimsToAddOrOverride).
-    #
     # At the AgentCore Gateway, the JWT Authorizer maps ALL token claims
     # (both standard and custom) to Cedar principal tags:
     #   Custom claim "user_id"    → principal.getTag("user_id")

--- a/infra-cdk/lib/backend-stack.ts
+++ b/infra-cdk/lib/backend-stack.ts
@@ -969,6 +969,7 @@ export class BackendStack extends cdk.NestedStack {
           "bedrock-agentcore:UpdateGateway",
           "bedrock-agentcore:GetGateway",
           "bedrock-agentcore:ManageResourceScopedPolicy",
+          "bedrock-agentcore:ListGatewayTargets",
         ],
         resources: [gateway.attrGatewayArn],
       })

--- a/infra-cdk/lib/cognito-stack.ts
+++ b/infra-cdk/lib/cognito-stack.ts
@@ -121,16 +121,15 @@ export class CognitoStack extends cdk.NestedStack {
     // This Lambda fires on M2M token generation (Client Credentials flow) and injects
     // custom claims (user_id, department, role) into the M2M access token.
     // These are application-defined claims, not standard JWT/OIDC claims.
-    // The claims are read from clientMetadata.verified_user_id, which is passed via
-    // the aws_client_metadata parameter in the direct Cognito /oauth2/token call
-    // (see patterns/utils/auth.py — get_gateway_access_token).
+    // The claims are read from clientMetadata.verified_user_id (the Cognito sub / UUID),
+    // which is passed via the aws_client_metadata parameter in the direct Cognito
+    // /oauth2/token call (see patterns/utils/auth.py — get_gateway_access_token).
     //
-    // For this demo, group assignment is hardcoded based on the user's email:
-    // - fastprojectadmin@* → department: "finance", role: "admin"
-    // - fastuser@*         → department: "engineering", role: "developer"
-    // - others (your own email) → department: "guest", role: "viewer"
+    // Group assignment uses a UUID-based mapping (USER_ROLE_MAP). On first deploy,
+    // all users are assigned "guest/viewer". After deploy, look up user subs and
+    // update the mapping, then redeploy. See docs/IDENTITY_POLICY.md for details.
     //
-    // To use dynamic group assignment, replace the hardcoded logic in the
+    // To use dynamic group assignment, replace the hardcoded mapping in the
     // Pre-Token Lambda (infra-cdk/lambdas/pretoken-v3/index.py) with a
     // DynamoDB lookup, directory service query, or other identity provider.
     const preTokenLambda = new lambda.Function(this, "PreTokenLambda", {


### PR DESCRIPTION
# fix: UUID-based identity mapping and IAM permission fixes

## Summary

Fixes the Pre-Token Lambda's identity resolution by replacing email-based substring matching with a proper UUID-based `USER_ROLE_MAP` dictionary. Also adds the `ListGatewayTargets` IAM permission required by AgentCore's policy creation validation, and updates all documentation to consistently use UUID placeholders instead of email addresses.

## Motivation

The Pre-Token Lambda received `verified_user_id` from `aws_client_metadata` which is the Cognito `sub` (uuid). The existing email-based substring matching logic (`if "fastprojectadmin" in user_id.lower()`) is not compatible with UUID identifiers. This update uses proper UUID-keyed dictionary mapping that correctly resolves user identity for Cedar policy evaluation.

Additionally, AgentCore validates Cedar policy action names against the Gateway's registered tools during `create_policy`. Without `ListGatewayTargets` permission on the Cedar Policy Lambda, policy creation fails with an access denied error.

## Changes

### Infrastructure (`infra-cdk/`)

#### Modified Files

- **lambdas/pretoken-v3/index.py** (full rewrite of mapping logic):
  - Replaced email-based if/else logic with `USER_ROLE_MAP` dictionary keyed by UUID placeholders
  - Added early return when no `verified_user_id` in metadata (instead of proceeding with empty string)
  - Added clear setup instructions in comments
  - Consolidated print statements into a single `f"[PRE-TOKEN] Assigned: department={department}, role={role}"` line

- **lib/backend-stack.ts**:
  - Added `bedrock-agentcore:ListGatewayTargets` to the Cedar Policy Lambda's IAM permissions
  - This permission is required because AgentCore validates Cedar policy action names against the Gateway's registered tools during `create_policy`

- **lib/cognito-stack.ts** (comment updates):
  - Updated comments to reflect UUID-based mapping approach
  - Added reference to two-step deployment process

### Documentation (`docs/`)

#### Modified Files

- **docs/IDENTITY_POLICY.md**:
  - Updated group assignment table from email patterns to UUID placeholders
  - Added two-step deployment instructions (deploy → look up UUIDs → update map → redeploy)
  - Added email-based alternative section (ListUsers API approach)
  - Updated "Changing Group Assignment" with DynamoDB/ListUsers/external directory options
  - Updated Runtime-Level Access Control code example to use `USER_ROLE_MAP` dict

- **docs/CEDAR_POLICY_GUIDE.md**:
  - Changed `user_id` example values from `"yourname@company.com"` to `"<cognito-sub-uuid>"`
  - Updated Capability 3 to use UUID placeholder
  - Updated Capability 4 (wildcard matching) to use a custom `email` claim instead of `user_id` (since `user_id` is a UUID, not matchable with `like "*@example.com"`)

- **docs/REPLACING_COGNITO.md**:
  - Changed `alice@company.com` → `<user-sub-uuid>` in Gateway Interceptor examples
  - Changed `"sub": "alice"` → `"sub": "<user-sub-uuid>"` in token comparison diagrams
  - Updated `get_user_groups()` to resolve UUID to username via `ListUsers` before calling `AdminListGroupsForUser`

## Security Considerations

- **No credentials logged**: The Pre-Token Lambda logs the assigned department/role but never prints the actual UUID value
- **UUID over email**: UUIDs are immutable, unique, and not PII — making them a safer identifier for authorization decisions than email addresses
- **Early return**: When no `verified_user_id` is present in metadata, the Lambda returns immediately without injecting any claims (fail-closed behavior)

## Testing

- [x] **CDK Deploy**: Stack deploys successfully with ListGatewayTargets permission — Cedar Policy Engine creates and attaches without errors
- [x] **CDK Destroy**: Stack destroys cleanly
- [x] **Pre-Token Lambda**: CloudWatch logs confirm UUID-based group assignment (guest/viewer for unmapped users, correct department/role for mapped users)
- [x] **Cedar Policy V1 (Allow)**: Guest user (unmapped UUID) can access Gateway tool
- [x] **Cedar Policy V2 (Deny)**: Guest user denied when policy restricts to finance/engineering only
- [x] **Policy Creation**: `create_policy` succeeds with ListGatewayTargets permission
- [x] **PII/Credential Scan**: No credentials, account IDs, or real UUIDs in committed code

## Files Changed (6)

### Modified (6)
1. `infra-cdk/lambdas/pretoken-v3/index.py` — UUID-based USER_ROLE_MAP replacing email substring matching
2. `infra-cdk/lib/backend-stack.ts` — Added ListGatewayTargets IAM permission to Cedar Policy Lambda
3. `infra-cdk/lib/cognito-stack.ts` — Updated comments to reflect UUID mapping approach
4. `docs/IDENTITY_POLICY.md` — UUID placeholders, two-step deploy instructions, email alternative
5. `docs/CEDAR_POLICY_GUIDE.md` — UUID placeholders in examples, email claim for wildcard matching
6. `docs/REPLACING_COGNITO.md` — UUID placeholders, ListUsers resolution in get_user_groups()

## Key Architectural Decisions

1. **UUID (Cognito sub) as the identifier**: The Cognito `sub` is immutable, unique, and not PII. It is the recommended identifier for authorization decisions. 

2. **Two-step deployment**: The `USER_ROLE_MAP` uses placeholder UUIDs on first deploy (all users get `guest/viewer`). After deploy, administrators look up actual user subs and update the map. This is intentional — UUIDs are only known after user creation.

3. **Email-based alternative documented but not default**: For teams that prefer email matching without the two-step deploy, the documentation provides instructions for adding Cognito `ListUsers` resolution in the Pre-Token Lambda. UUID-based mapping remains the recommended default.

4. **ListGatewayTargets on Cedar Policy Lambda (not Gateway Role)**: This permission is needed by the Lambda (the caller of `create_policy`), not by the Gateway Role. AgentCore validates Cedar action names against the Gateway's registered tools during policy creation, requiring the caller to have list access.

## Additional Notes

- **No changes to cedar-policy/index.py**: The policy creation/deletion sequence and Custom Resource lifecycle logic are unchanged from main. Only the IAM permission in backend-stack.ts was added.
- **Placeholder UUIDs**: All documentation uses `<cognito-sub-uuid>`, `<fastprojectadmin-user-sub-uuid>`, etc. No real UUIDs, account IDs, or email addresses appear in the committed code.

