### PR TITLE
Fix/agui strands session memory

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -302,7 +302,13 @@ cd infra-cdk
 cdk destroy --force
 ```
 
-If you deployed via CodeBuild (Option B), its build resources are already removed on success (or on the next successful run) — only the deployed FAST stack above needs tearing down.
+If you deployed via CodeBuild (Option B), its build resources are already removed on success (or on the next successful run) — only the deployed FAST stack above needs tearing down. If you don't have CDK installed locally (the CodeBuild path doesn't require it), delete the stack directly:
+
+```bash
+aws cloudformation delete-stack --stack-name <stack_name_base>
+```
+
+Like `cdk destroy`, this removes the FAST stack but not the CDK bootstrap or asset buckets.
 
 **Warning**: `cdk destroy` will delete all data including S3 buckets created during deployment and ECR images.
 

--- a/patterns/agui-strands-agent/agent.py
+++ b/patterns/agui-strands-agent/agent.py
@@ -6,7 +6,7 @@ import logging
 import os
 
 from ag_ui.core import RunAgentInput, RunErrorEvent
-from ag_ui_strands import StrandsAgent
+from ag_ui_strands import StrandsAgent, StrandsAgentConfig
 from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig
 from bedrock_agentcore.memory.integrations.strands.session_manager import (
     AgentCoreMemorySessionManager,
@@ -37,36 +37,48 @@ MODEL = BedrockModel(
 CODE_INTERPRETER = StrandsCodeInterpreterTools(REGION).execute_python_securely
 
 
-def get_memory_session_manager(
-    actor_id: str, session_id: str
-) -> AgentCoreMemorySessionManager | None:
-    """Return an AgentCore Memory session manager, or None when MEMORY_ID is unset."""
-    if not MEMORY_ID:
-        return None
-    return AgentCoreMemorySessionManager(
-        AgentCoreMemoryConfig(
-            memory_id=MEMORY_ID, session_id=session_id, actor_id=actor_id
-        ),
-        region_name=REGION,
-    )
+def _make_session_manager_provider(actor_id: str):
+    """Per-thread AgentCore Memory session-manager factory for the AG-UI adapter.
+
+    ag-ui-strands attaches the returned manager to the agent it runs (keyed by
+    actor_id + thread_id). A session_manager on the template Agent is ignored.
+    Returns None when MEMORY_ID is unset.
+    """
+
+    def provider(run_input: RunAgentInput) -> AgentCoreMemorySessionManager | None:
+        if not MEMORY_ID:
+            return None
+        session_id = run_input.thread_id or actor_id
+        return AgentCoreMemorySessionManager(
+            AgentCoreMemoryConfig(
+                memory_id=MEMORY_ID, session_id=session_id, actor_id=actor_id
+            ),
+            region_name=REGION,
+        )
+
+    return provider
 
 
 @app.entrypoint
 async def invocations(payload: dict, context: RequestContext):
     input_data = RunAgentInput.model_validate(payload)
     actor_id = extract_user_id_from_context(context)
-    session_id = input_data.thread_id or actor_id
 
+    # session_manager is supplied per-thread via the provider below, not here.
     agent = Agent(
         model=MODEL,
         system_prompt=SYSTEM_PROMPT,
         tools=[create_gateway_mcp_client(actor_id), CODE_INTERPRETER],
-        session_manager=get_memory_session_manager(actor_id, session_id),
     )
     agui_agent = StrandsAgent(
         agent=agent,
         name="agui_strands_agent",
         description="AG-UI Strands agent with Gateway MCP tools and Code Interpreter",
+        config=StrandsAgentConfig(
+            session_manager_provider=_make_session_manager_provider(actor_id),
+            # Disable client-side replay so the session manager owns history.
+            replay_history_into_strands=False,
+        ),
     )
 
     try:

--- a/patterns/agui-strands-agent/requirements.txt
+++ b/patterns/agui-strands-agent/requirements.txt
@@ -1,6 +1,6 @@
 # Strands AG-UI agent dependencies
-strands-agents==1.32.0
-ag-ui-strands==0.1.1
-bedrock-agentcore==1.4.7
-mcp==1.26.0
-PyJWT[crypto]==2.12.1
+strands-agents==1.42.0
+ag-ui-strands==0.1.9
+bedrock-agentcore==1.14.0
+mcp==1.27.2
+PyJWT[crypto]==2.13.0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -63,7 +63,7 @@ python scripts/deploy-with-codebuild.py
 
 Packages your git-tracked source and runs the full deployment in the cloud via a CodeBuild project, streaming logs to your terminal. On a **successful** build, all created resources (S3 source bucket, CodeBuild project, IAM role, permission boundary) are removed. On a **failed** build, they are retained for debugging and reused on the next run.
 
-Only git-tracked or staged files are deployed — stage or commit first, as untracked files are skipped with a warning. This does not remove your deployed FAST stack; for that, run `cd infra-cdk && cdk destroy`.
+Only git-tracked or staged files are deployed — stage or commit first, as untracked files are skipped with a warning. This does not remove your deployed FAST stack; to tear that down, run `cd infra-cdk && cdk destroy`, or `aws cloudformation delete-stack --stack-name <stack_name_base>` if you don't have CDK installed locally.
 
 The IAM role has `AdministratorAccess` constrained by a permission boundary that denies dangerous actions (`iam:CreateUser`, `iam:CreateAccessKey`, `organizations:*`, etc.) to prevent privilege escalation.
 


### PR DESCRIPTION
## Problem

`agui-strands-agent` lost same-session memory recall. The `ag-ui-strands` adapter dropped the `AgentCoreMemorySessionManager` (0.1.1 never forwarded it; 0.1.9 checks `agent.session_manager` but Strands stores `_session_manager`, so its replay path overwrote rehydrated history with just the latest message).

## Solution

- Bump `ag-ui-strands` 0.1.1 → 0.1.9 (+ other deps to latest).
- Wire the session manager per-thread via `StrandsAgentConfig.session_manager_provider`.
- Set `replay_history_into_strands=False` so the session manager owns history.

Recall now uses AgentCore Memory only.

Also includes docs: CloudFormation teardown for CodeBuild deployments.