### PR TITLE
docs: update DynamoDB on-demand pricing to current rates

### DIFF
--- a/docs/SESSION_MANAGEMENT.md
+++ b/docs/SESSION_MANAGEMENT.md
@@ -272,7 +272,7 @@ new ssm.StringParameter(this, "SessionsApiUrlParam", {
 
 | Resource | Cost | Notes |
 |----------|------|-------|
-| DynamoDB (on-demand) | ~$1.25 per million writes, ~$0.25 per million reads | Negligible for most apps |
+| DynamoDB (on-demand) | ~$0.625 per million writes, ~$0.125 per million reads | Negligible for most apps |
 | API Gateway | $3.50 per million requests | Shared with other routes |
 | Lambda | Free tier covers 1M requests/month | Minimal compute |
 


### PR DESCRIPTION
### Update DynamoDB on-demand pricing to current rates

AWS reduced DynamoDB on-demand throughput prices by 50%, effective **November 1, 2024**
([announcement](https://aws.amazon.com/blogs/database/new-amazon-dynamodb-lowers-pricing-for-on-demand-throughput-and-global-tables/)). This file still lists the pre-cut rates, overstating on-demand
throughput cost by 2x.

| | Before | After |
|---|---|---|
| Write request units | $1.25 /M | **$0.625 /M** |
| Read request units (strongly consistent) | $0.25 /M | **$0.125 /M** |

Verifiable against the AWS Price List API, which is authoritative and versioned:

```
https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonDynamoDB/current/region_index.json
```

#### Scope of this change

Only the two on-demand throughput rates are changed. Deliberately **not** touched, because the
2024 price cut did not apply to them:

- Storage at `$0.25/GB-month`
- Provisioned capacity at `$0.00065/WCU-hr` and `$0.00013/RCU-hr`
- Transactional writes, which are `$1.25/M` -- the same figure as the *stale* standard-write rate
- Eventually-consistent reads, which are `$0.0625/M` post-cut

That last pair is the easy trap in review: `$1.25/M` is both the stale standard-write rate and the
correct transactional-write rate, and `$0.125/M` is both the stale eventual-read rate and the
correct strongly-consistent read rate. Each line changed here was read in context to confirm it
refers to standard on-demand throughput.
