### PR TITLE
feat: add dynamic MCP servers with per-user preferences

### DIFF
--- a/docs/MCP_SERVERS.md
+++ b/docs/MCP_SERVERS.md
@@ -1,0 +1,169 @@
+# Dynamic MCP Servers
+
+Connect additional MCP servers to your FAST agent through the AgentCore Gateway. Users can enable or disable individual servers from the chat UI without redeploying.
+
+## Overview
+
+FAST supports registering external MCP servers (streamable-HTTP endpoints) alongside the built-in Lambda tool target. The feature has three parts:
+
+1. **Deploy-time catalog** — declared in `config.yaml` (CDK) or `terraform.tfvars` (Terraform).
+2. **Per-user preferences** — each user toggles servers on/off from a settings dialog; state persists across sessions and devices in DynamoDB.
+3. **Runtime filtering** — the agent loads only tools from servers the calling user has enabled.
+
+## Quick Start
+
+Add entries to `infra-cdk/config.yaml`:
+
+```yaml
+backend:
+  mcp_servers:
+    - id: aws-knowledge
+      name: AWS Knowledge
+      description: Up-to-date AWS docs, API references, and blog content.
+      endpoint: https://knowledge-mcp.global.api.aws
+
+    - id: my-internal-mcp
+      name: Internal Tools
+      endpoint: https://tools.internal.example.com/mcp
+      default_enabled: false
+      auth:
+        type: OAUTH
+        client_id: my-client-id
+        client_secret_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf
+        discovery_url: https://auth.example.com/.well-known/openid-configuration
+        scopes:
+          - mcp/invoke
+```
+
+Deploy with `cdk deploy`. The new servers appear in every user's settings view.
+
+## Configuration Reference
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `id` | Yes | — | Stable identifier (alphanumeric + hyphens). Used in resource names. |
+| `name` | Yes | — | Human-readable label shown in the settings UI. |
+| `description` | No | `""` | Shown below the server name in the settings dialog. |
+| `endpoint` | Yes | — | HTTPS URL of the streamable-HTTP MCP server. |
+| `enabled` | No | `true` | Set `false` to keep the entry in config without deploying it. |
+| `default_enabled` | No | `true` | Initial on/off state for users who haven't set preferences yet. |
+| `auth.type` | No | `"NONE"` | `NONE` (public) or `OAUTH` (client-credentials M2M). |
+
+### OAUTH fields (required when `auth.type: OAUTH`)
+
+| Field | Description |
+|-------|-------------|
+| `client_id` | OAuth2 client ID (plaintext). Mutually exclusive with `client_id_secret_arn`. |
+| `client_id_secret_arn` | Secrets Manager ARN holding the client ID. Mutually exclusive with `client_id`. |
+| `client_secret_secret_arn` | Secrets Manager ARN holding the client secret. Never embedded in templates. |
+| `discovery_url` | OIDC discovery URL of the authorization server. |
+| `scopes` | List of OAuth2 scopes to request (optional, defaults to `[]`). |
+
+## Supported Transport Types
+
+| Type | Supported | Notes |
+|------|-----------|-------|
+| Streamable HTTP (`https://`) | Yes | Phase 1 only supports this. |
+| stdio (`command` + `args`) | No | Rejected at validation time. AgentCore Gateway speaks HTTP MCP only. |
+
+## Auth Types
+
+| Type | Description |
+|------|-------------|
+| `NONE` | Public, unauthenticated MCP endpoint. No credential configuration on the gateway target. |
+| `OAUTH` | OAuth2 Client Credentials (M2M) via AgentCore Token Vault. Uses native `AWS::BedrockAgentCore::OAuth2CredentialProvider`. |
+| `IAM_SIGV4` | Not supported on MCP-server targets (Gateway limitation). |
+| `API_KEY` | Not supported on MCP-server targets (Gateway limitation). |
+
+## Architecture
+
+```
+┌───────────┐     ┌──────────────┐     ┌─────────────────┐
+│  Frontend │────▶│  API Gateway │────▶│ mcp-prefs Lambda │──▶ DynamoDB
+│  (Dialog) │     │ GET/PUT      │     │ (per-user prefs) │    (mcp-prefs table)
+└───────────┘     └──────────────┘     └─────────────────┘
+
+┌───────────┐     ┌──────────────────┐     ┌───────────────────┐
+│   Agent   │────▶│ AgentCore Gateway│────▶│ MCP Server Target │
+│  Runtime  │     │ (tools/list)     │     │ (streamable HTTP) │
+└───────────┘     └──────────────────┘     └───────────────────┘
+      │
+      ▼
+  mcp_prefs.py
+  (filter tools by user's enabled list from DynamoDB)
+```
+
+## How Per-User Filtering Works
+
+1. On each request, the agent runtime reads the user's enabled-server list from DynamoDB (`MCP_PREFS_TABLE`).
+2. Users with no saved preferences get the catalog's `default_enabled` set.
+3. A Strands `tool_filters` callback rejects tools whose names contain the target marker (`mcp-{disabled_id}___`).
+4. Fail-open: if DynamoDB is unreachable, catalog defaults are used and the agent keeps responding.
+5. Built-in tools (sample Lambda target, Code Interpreter) are never filtered.
+
+## Settings UI
+
+After logging in, click the gear icon in the chat header. The dialog shows each catalog server with:
+
+- Name and description
+- On/off checkbox
+- Save button (changes apply on the user's next message)
+
+Empty state: "No additional MCP servers are configured for this deployment" when `backend.mcp_servers` is empty or absent.
+
+## Terraform
+
+The equivalent Terraform configuration uses a variable:
+
+```hcl
+mcp_servers = [
+  {
+    id          = "aws-knowledge"
+    name        = "AWS Knowledge"
+    description = "Up-to-date AWS docs, API references, and blog content."
+    endpoint    = "https://knowledge-mcp.global.api.aws"
+  },
+  {
+    id              = "my-oauth-mcp"
+    name            = "My OAuth MCP"
+    endpoint        = "https://secure-mcp.example.com/mcp"
+    default_enabled = false
+    auth = {
+      type                     = "OAUTH"
+      client_id                = "my-client-id"
+      client_secret_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret"
+      discovery_url            = "https://auth.example.com/.well-known/openid-configuration"
+      scopes                   = ["mcp/invoke"]
+    }
+  },
+]
+```
+
+## Cedar Policy Considerations
+
+The default Cedar policy permits all gateway tools for authenticated users. Per-user MCP server enable/disable is enforced at the agent runtime layer (tool filtering), not at the Cedar policy layer. This is intentional: MCP-server tool names are only known after gateway target sync, so they cannot be enumerated in Cedar at deploy time.
+
+If you need to restrict specific MCP tools by user department or role, you can add targeted Cedar `forbid` statements after deploying and observing the tool names (format: `mcp-{id}___{tool_name}`).
+
+## Tool Name Format
+
+Gateway tools follow the naming convention: `{target_name}___{tool_name}` (triple underscore).
+
+With the Strands `MCPClient` prefix `"gateway"`, the full tool name visible to the agent is:
+```
+gateway_{target_name}___{tool_name}
+```
+
+Example: `gateway_mcp-aws-knowledge___aws___search_documentation`
+
+Target names are kept short (`mcp-{id}`) to stay within Bedrock's 64-character tool-name limit.
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Server not in settings | `enabled: false` in config | Set `enabled: true` or remove the field |
+| Gateway target stuck in CREATING | Endpoint unreachable or returns errors | Verify endpoint responds to MCP `initialize` |
+| Tool name too long (>64 chars) | Server exposes tools with long names | Use a shorter `id` in config, or ask the MCP server maintainer to shorten tool names |
+| OAUTH target fails | Invalid credentials or discovery URL | Check Secrets Manager values and that the discovery URL returns valid OIDC metadata |
+| User toggle not taking effect | Agent uses cached tool list | Effect is per-message; send a new message after saving |

--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react"
 import { Button } from "@/components/ui/button"
-import { Plus } from "lucide-react"
+import { Plus, Settings } from "lucide-react"
 import { useAuth } from "@/hooks/useAuth"
+import { McpServersDialog } from "./McpServersDialog"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,6 +23,7 @@ type ChatHeaderProps = {
 
 export function ChatHeader({ title, onNewChat, canStartNewChat }: ChatHeaderProps) {
   const { isAuthenticated, signOut } = useAuth()
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false)
 
   return (
     <header className="flex items-center justify-between p-4 border-b w-full">
@@ -32,6 +35,19 @@ export function ChatHeader({ title, onNewChat, canStartNewChat }: ChatHeaderProp
           <Plus className="h-4 w-4" />
           New Chat
         </Button>
+        {isAuthenticated && (
+          <>
+            <Button
+              variant="outline"
+              size="icon"
+              aria-label="MCP server settings"
+              onClick={() => setIsSettingsOpen(true)}
+            >
+              <Settings className="h-4 w-4" />
+            </Button>
+            <McpServersDialog isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
+          </>
+        )}
         {isAuthenticated && (
           <AlertDialog>
             <AlertDialogTrigger asChild>

--- a/frontend/src/components/chat/McpServersDialog.tsx
+++ b/frontend/src/components/chat/McpServersDialog.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { fetchMcpServers, saveMcpServers, type McpServer } from "@/services/mcpServerService"
+import { useAuth } from "@/hooks/useAuth"
+
+interface McpServersDialogProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+/**
+ * Settings dialog listing the deployment's MCP servers with per-user on/off
+ * toggles. Saved preferences take effect on the user's next message.
+ */
+export function McpServersDialog({ isOpen, onClose }: McpServersDialogProps) {
+  const { token } = useAuth()
+  const [servers, setServers] = useState<McpServer[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isOpen || !token) return
+    setIsLoading(true)
+    setError(null)
+    fetchMcpServers(token)
+      .then(setServers)
+      .catch(() => setError("Failed to load MCP servers."))
+      .finally(() => setIsLoading(false))
+  }, [isOpen, token])
+
+  const toggle = (id: string) => {
+    setServers(prev => prev.map(s => (s.id === id ? { ...s, enabled: !s.enabled } : s)))
+  }
+
+  const handleSave = async () => {
+    if (!token) return
+    setIsSaving(true)
+    setError(null)
+    try {
+      await saveMcpServers(
+        servers.filter(s => s.enabled).map(s => s.id),
+        token
+      )
+      onClose()
+    } catch {
+      setError("Failed to save preferences.")
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>MCP Servers</DialogTitle>
+          <DialogDescription>
+            Choose which tool servers the assistant can use. Changes apply to your next message.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 max-h-72 overflow-y-auto">
+          {isLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+          {!isLoading && servers.length === 0 && !error && (
+            <p className="text-sm text-muted-foreground">
+              No additional MCP servers are configured for this deployment.
+            </p>
+          )}
+          {servers.map(server => (
+            <label
+              key={server.id}
+              className="flex items-start gap-3 rounded-md border p-3 cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={server.enabled}
+                onChange={() => toggle(server.id)}
+                className="mt-1 h-4 w-4 accent-primary"
+              />
+              <span>
+                <span className="block text-sm font-medium">{server.name}</span>
+                {server.description && (
+                  <span className="block text-xs text-muted-foreground">{server.description}</span>
+                )}
+              </span>
+            </label>
+          ))}
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={isSaving || isLoading || servers.length === 0}
+          >
+            {isSaving ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/services/mcpServerService.ts
+++ b/frontend/src/services/mcpServerService.ts
@@ -1,0 +1,65 @@
+/**
+ * MCP Server Preferences Service
+ * Reads the MCP server catalog with the current user's toggles and saves updates.
+ * Endpoints live on the same API Gateway as the feedback API (GET/PUT /mcp-servers).
+ */
+
+let MCP_SERVERS_API_URL = ""
+
+async function loadApiUrl(): Promise<string> {
+  if (MCP_SERVERS_API_URL) {
+    return MCP_SERVERS_API_URL
+  }
+
+  const response = await fetch("/aws-exports.json")
+  const config = await response.json()
+  if (!config.feedbackApiUrl) {
+    throw new Error("API URL not configured")
+  }
+  MCP_SERVERS_API_URL = `${config.feedbackApiUrl}mcp-servers`
+  return MCP_SERVERS_API_URL
+}
+
+export interface McpServer {
+  id: string
+  name: string
+  description: string
+  enabled: boolean
+}
+
+/**
+ * Fetch the MCP server catalog with the calling user's enabled/disabled state.
+ * Returns [] when the deployment has no MCP servers configured (route absent).
+ */
+export async function fetchMcpServers(idToken: string): Promise<McpServer[]> {
+  const apiUrl = await loadApiUrl()
+  const response = await fetch(apiUrl, {
+    headers: { Authorization: `Bearer ${idToken}` },
+  })
+  if (response.status === 403 || response.status === 404) {
+    // Deployment without backend.mcp_servers — feature disabled.
+    return []
+  }
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`)
+  }
+  const data = await response.json()
+  return data.servers ?? []
+}
+
+/** Save the calling user's enabled MCP server ids. */
+export async function saveMcpServers(enabledIds: string[], idToken: string): Promise<void> {
+  const apiUrl = await loadApiUrl()
+  const response = await fetch(apiUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${idToken}`,
+    },
+    body: JSON.stringify({ enabled: enabledIds }),
+  })
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new Error(errorData.error || `HTTP error! status: ${response.status}`)
+  }
+}

--- a/gateway/policies/policy.cedar
+++ b/gateway/policies/policy.cedar
@@ -36,11 +36,17 @@
 // ========================================
 // VERSION 1: Guest Has Full Access (Testing "Allow" Case)
 // ========================================
-// All departments (finance, engineering, guest) can access the tool.
+// All departments (finance, engineering, guest) can access every gateway tool.
+// No action constraint: this covers the sample tool AND tools from any MCP
+// servers configured via backend.mcp_servers (their tool names are only known
+// at runtime, so they cannot be enumerated here). Per-user MCP server
+// enable/disable is enforced by the agent runtime (tools/mcp_prefs.py), not
+// by this policy. To restrict specific tools by department, add an action
+// constraint as shown in VERSION 2.
 
 permit(
   principal is AgentCore::OAuthUser,
-  action == AgentCore::Action::"sample-tool-target___text_analysis_tool",
+  action,
   resource == AgentCore::Gateway::"{{GATEWAY_ARN}}"
 )
 when {

--- a/infra-cdk/config.yaml
+++ b/infra-cdk/config.yaml
@@ -34,3 +34,24 @@ backend:
   #     - subnet-cccc3333dddd4444e
   #   security_group_ids:  # Optional - a default SG is created if omitted
   #     - sg-0abc1234def56789a
+
+  # Additional MCP servers exposed to the agent through the AgentCore Gateway.
+  # Only streamable-HTTP MCP endpoints are supported (no stdio command/args).
+  # auth.type: NONE (default) or OAUTH (client-credentials via Secrets Manager).
+  # mcp_servers:
+  #   - id: my-public-mcp            # alphanumeric + hyphens; used in resource names
+  #     name: My Public MCP
+  #     description: Example unauthenticated MCP server
+  #     endpoint: https://mcp.example.com/mcp
+  #   - id: my-oauth-mcp
+  #     name: My OAuth MCP
+  #     endpoint: https://secure-mcp.example.com/mcp
+  #     enabled: true                # set false to keep the entry without deploying it
+  #     default_enabled: true        # initial on/off state for users who haven't set preferences
+  #     auth:
+  #       type: OAUTH
+  #       client_id: my-client-id    # or client_id_secret_arn: arn:aws:secretsmanager:...
+  #       client_secret_secret_arn: arn:aws:secretsmanager:us-east-1:123456789012:secret:my-mcp-secret-AbCdEf
+  #       discovery_url: https://auth.example.com/.well-known/openid-configuration
+  #       scopes:
+  #         - mcp/invoke

--- a/infra-cdk/lambdas/cedar-policy/index.py
+++ b/infra-cdk/lambdas/cedar-policy/index.py
@@ -95,15 +95,30 @@ def handle_create(props: dict) -> dict:
     description = props.get("Description", "Cedar policy for AgentCore Gateway")
     engine_name = props["PolicyEngineName"]
 
-    # Step 1: Create Policy Engine
+    # Step 1: Create Policy Engine (idempotent).
+    # Engine creation can outlive one Lambda invocation; on the retry the
+    # create call raises ConflictException, so reuse the existing engine by
+    # name instead of failing the whole deployment.
     logger.info(f"Creating Policy Engine: {engine_name}")
-    engine_response = client.create_policy_engine(
-        name=engine_name,
-        description=f"Policy engine for gateway {gateway_id}",
-        clientToken=str(uuid.uuid4()),
-    )
-    policy_engine_id = engine_response["policyEngineId"]
-    logger.info(f"Policy Engine created: {policy_engine_id}")
+    try:
+        engine_response = client.create_policy_engine(
+            name=engine_name,
+            description=f"Policy engine for gateway {gateway_id}",
+            clientToken=str(uuid.uuid4()),
+        )
+        policy_engine_id = engine_response["policyEngineId"]
+        logger.info(f"Policy Engine created: {policy_engine_id}")
+    except client.exceptions.ConflictException:
+        policy_engine_id = _find_policy_engine_by_name(engine_name)
+        if not policy_engine_id:
+            raise
+        logger.warning(
+            f"Policy Engine {engine_name} already exists — reusing {policy_engine_id} "
+            "(idempotent retry)"
+        )
+        # A previous partial attempt may have created a policy already;
+        # remove managed policies so this attempt starts clean.
+        _delete_managed_policies(policy_engine_id, "unknown", props)
 
     # Wait for Policy Engine to become ACTIVE using official waiter
     logger.info(f"Waiting for Policy Engine {policy_engine_id} to become ACTIVE...")
@@ -298,6 +313,20 @@ def handle_delete(event: dict, props: dict) -> dict:
         logger.warning(f"Could not delete Policy Engine {policy_engine_id}: {e}")
 
     return {"PhysicalResourceId": physical_id}
+
+
+def _find_policy_engine_by_name(engine_name: str) -> str | None:
+    """Return the policyEngineId of the engine with the given name, if any."""
+    token = None
+    while True:
+        kwargs = {"nextToken": token} if token else {}
+        page = client.list_policy_engines(**kwargs)
+        for engine in page.get("items", []):
+            if engine.get("name") == engine_name:
+                return engine.get("policyEngineId")
+        token = page.get("nextToken")
+        if not token:
+            return None
 
 
 def _delete_managed_policies(

--- a/infra-cdk/lambdas/mcp-prefs/index.py
+++ b/infra-cdk/lambdas/mcp-prefs/index.py
@@ -1,0 +1,103 @@
+"""Per-user MCP server preferences API.
+
+GET /mcp-servers
+    Returns the deploy-time MCP server catalog merged with the calling user's
+    enabled/disabled toggles. Users with no saved preferences get the catalog
+    defaults (default_enabled).
+
+    Response 200: {"servers": [{"id", "name", "description", "enabled"}]}
+
+PUT /mcp-servers
+    Saves the calling user's enabled-servers list. Ids not present in the
+    catalog are silently dropped (catalog is authoritative; stale entries are
+    ignored per the requirements).
+
+    Request body: {"enabled": ["server-id", ...]}
+    Response 200: {"success": true, "enabled": ["server-id", ...]}
+
+The user is always identified from the validated Cognito JWT claims provided
+by the API Gateway Cognito authorizer — never from the request body.
+"""
+
+import json
+import os
+import time
+
+import boto3
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.event_handler import APIGatewayRestResolver, CORSConfig
+from aws_lambda_powertools.event_handler.exceptions import BadRequestError, UnauthorizedError
+from aws_lambda_powertools.logging import correlation_paths
+
+logger = Logger(service="mcp-prefs")
+
+TABLE_NAME = os.environ["TABLE_NAME"]
+# Catalog is deploy-time config injected by CDK: [{id, name, description, default_enabled}]
+CATALOG: list[dict] = json.loads(os.environ.get("MCP_SERVERS_CATALOG", "[]"))
+CATALOG_IDS = {s["id"] for s in CATALOG}
+
+_origins = [o.strip() for o in os.environ.get("CORS_ALLOWED_ORIGINS", "*").split(",") if o.strip()]
+cors_config = CORSConfig(
+    allow_origin=_origins[0],
+    extra_origins=_origins[1:],
+    allow_headers=["Content-Type", "Authorization"],
+    allow_credentials=True,
+)
+
+app = APIGatewayRestResolver(cors=cors_config)
+dynamodb = boto3.resource("dynamodb")
+table = dynamodb.Table(TABLE_NAME)
+
+
+def _user_id() -> str:
+    authorizer = app.current_event.request_context.authorizer
+    claims = authorizer.get("claims", {}) if authorizer else {}
+    user_id = claims.get("sub")
+    if not user_id:
+        raise UnauthorizedError("Missing user identity")
+    return user_id
+
+
+def _enabled_ids_for(user_id: str) -> set[str]:
+    """The user's enabled server ids, falling back to catalog defaults."""
+    item = table.get_item(Key={"userId": user_id}).get("Item")
+    if item is None:
+        return {s["id"] for s in CATALOG if s.get("default_enabled", True)}
+    # Intersect with the catalog: servers removed from config are silently ignored.
+    return set(item.get("enabled", [])) & CATALOG_IDS
+
+
+@app.get("/mcp-servers")
+def get_servers() -> dict:
+    enabled = _enabled_ids_for(_user_id())
+    return {
+        "servers": [
+            {
+                "id": s["id"],
+                "name": s["name"],
+                "description": s.get("description", ""),
+                "enabled": s["id"] in enabled,
+            }
+            for s in CATALOG
+        ]
+    }
+
+
+@app.put("/mcp-servers")
+def put_servers() -> dict:
+    user_id = _user_id()
+    body = app.current_event.json_body or {}
+    requested = body.get("enabled")
+    if not isinstance(requested, list) or not all(isinstance(i, str) for i in requested):
+        raise BadRequestError("body.enabled must be a list of server ids")
+    enabled = sorted(set(requested) & CATALOG_IDS)
+    table.put_item(
+        Item={"userId": user_id, "enabled": enabled, "updatedAt": int(time.time())}
+    )
+    logger.info("Saved MCP preferences", extra={"userId": user_id, "enabled": enabled})
+    return {"success": True, "enabled": enabled}
+
+
+@logger.inject_lambda_context(correlation_id_path=correlation_paths.API_GATEWAY_REST)
+def handler(event: dict, context) -> dict:
+    return app.resolve(event, context)

--- a/infra-cdk/lambdas/mcp-prefs/index.py
+++ b/infra-cdk/lambdas/mcp-prefs/index.py
@@ -26,7 +26,10 @@ import time
 import boto3
 from aws_lambda_powertools import Logger
 from aws_lambda_powertools.event_handler import APIGatewayRestResolver, CORSConfig
-from aws_lambda_powertools.event_handler.exceptions import BadRequestError, UnauthorizedError
+from aws_lambda_powertools.event_handler.exceptions import (
+    BadRequestError,
+    UnauthorizedError,
+)
 from aws_lambda_powertools.logging import correlation_paths
 
 logger = Logger(service="mcp-prefs")

--- a/infra-cdk/lambdas/mcp-prefs/index.py
+++ b/infra-cdk/lambdas/mcp-prefs/index.py
@@ -39,7 +39,11 @@ TABLE_NAME = os.environ["TABLE_NAME"]
 CATALOG: list[dict] = json.loads(os.environ.get("MCP_SERVERS_CATALOG", "[]"))
 CATALOG_IDS = {s["id"] for s in CATALOG}
 
-_origins = [o.strip() for o in os.environ.get("CORS_ALLOWED_ORIGINS", "*").split(",") if o.strip()]
+_origins = [
+    o.strip()
+    for o in os.environ.get("CORS_ALLOWED_ORIGINS", "*").split(",")
+    if o.strip()
+]
 cors_config = CORSConfig(
     allow_origin=_origins[0],
     extra_origins=_origins[1:],
@@ -91,7 +95,9 @@ def put_servers() -> dict:
     user_id = _user_id()
     body = app.current_event.json_body or {}
     requested = body.get("enabled")
-    if not isinstance(requested, list) or not all(isinstance(i, str) for i in requested):
+    if not isinstance(requested, list) or not all(
+        isinstance(i, str) for i in requested
+    ):
         raise BadRequestError("body.enabled must be a list of server ids")
     enabled = sorted(set(requested) & CATALOG_IDS)
     table.put_item(

--- a/infra-cdk/lambdas/mcp-prefs/requirements.txt
+++ b/infra-cdk/lambdas/mcp-prefs/requirements.txt
@@ -1,0 +1,2 @@
+# Boto3 and aws-lambda-powertools come from the Lambda runtime / Powertools layer.
+# Nothing extra needed at runtime.

--- a/infra-cdk/lib/backend-construct.ts
+++ b/infra-cdk/lib/backend-construct.ts
@@ -16,6 +16,7 @@ import * as cr from "aws-cdk-lib/custom-resources"
 import { Construct } from "constructs"
 import { AppConfig } from "./utils/config-manager"
 import { AgentCoreRole } from "./utils/agentcore-role"
+import { attachMcpServerTargets } from "./utils/mcp-servers"
 import * as path from "path"
 import * as fs from "fs"
 
@@ -83,8 +84,12 @@ export class BackendConstruct extends Construct {
     // Create AgentCore Gateway (before Runtime)
     this.createAgentCoreGateway(props.config)
 
+    // Per-user MCP server preferences (only when backend.mcp_servers is configured).
+    // Created before the Runtime so the table name/grant can be wired into it.
+    const mcpPrefsTable = this.createMcpPrefsTable(props.config)
+
     // Create AgentCore Runtime resources
-    this.createAgentCoreRuntime(props.config)
+    this.createAgentCoreRuntime(props.config, mcpPrefsTable)
 
     // Store runtime ARN in SSM for frontend stack
     this.createRuntimeSSMParameters(props.config)
@@ -97,10 +102,40 @@ export class BackendConstruct extends Construct {
 
     // Create API Gateway Feedback API resources (example of best-practice API Gateway + Lambda
     // pattern)
-    this.createFeedbackApi(props.config, props.frontendUrl, feedbackTable)
+    this.createFeedbackApi(props.config, props.frontendUrl, feedbackTable, mcpPrefsTable)
   }
 
-  private createAgentCoreRuntime(config: AppConfig): void {
+  /**
+   * JSON catalog of configured MCP servers (id, name, description, default_enabled).
+   * Shared by the preferences API Lambda (to render the settings list) and the
+   * agent runtime (to compute per-user default enablement). Contains no secrets.
+   */
+  private mcpServersCatalogJson(config: AppConfig): string {
+    const entries = (config.backend.mcp_servers ?? []).filter(s => s.enabled !== false)
+    return JSON.stringify(
+      entries.map(s => ({
+        id: s.id,
+        name: s.name,
+        description: s.description ?? "",
+        default_enabled: s.default_enabled !== false,
+      }))
+    )
+  }
+
+  /** DynamoDB table holding each user's enabled-MCP-servers list. */
+  private createMcpPrefsTable(config: AppConfig): dynamodb.Table | undefined {
+    const hasServers = (config.backend.mcp_servers ?? []).some(s => s.enabled !== false)
+    if (!hasServers) return undefined
+    return new dynamodb.Table(this, "McpPrefsTable", {
+      tableName: `${config.stack_name_base}-mcp-prefs`,
+      partitionKey: { name: "userId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      encryption: dynamodb.TableEncryption.DEFAULT,
+    })
+  }
+
+  private createAgentCoreRuntime(config: AppConfig, mcpPrefsTable?: dynamodb.Table): void {
     const pattern = config.backend?.pattern || "strands-single-agent"
 
     const stack = cdk.Stack.of(this)
@@ -388,6 +423,15 @@ export class BackendConstruct extends Construct {
       envVars["CLAUDE_CODE_USE_BEDROCK"] = "1"
     }
 
+    // Per-user MCP server preferences: the agent reads the caller's enabled list
+    // from DynamoDB and filters gateway tools accordingly (see tools/mcp_prefs.py
+    // in the agent pattern). Absent when no MCP servers are configured.
+    if (mcpPrefsTable) {
+      envVars["MCP_PREFS_TABLE"] = mcpPrefsTable.tableName
+      envVars["MCP_SERVERS_CATALOG"] = this.mcpServersCatalogJson(config)
+      mcpPrefsTable.grantReadData(agentRole)
+    }
+
     // Create the runtime using L2 construct
     // requestHeaderConfiguration allows the agent to read the Authorization header
     // from RequestContext.request_headers, which is needed to securely extract the
@@ -540,7 +584,8 @@ export class BackendConstruct extends Construct {
   private createFeedbackApi(
     config: AppConfig,
     frontendUrl: string,
-    feedbackTable: dynamodb.Table
+    feedbackTable: dynamodb.Table,
+    mcpPrefsTable?: dynamodb.Table
   ): void {
     // Create Lambda function for feedback using Python
     // ARM_64 required — matches Powertools ARM64 layer and avoids cross-platform
@@ -585,7 +630,7 @@ export class BackendConstruct extends Construct {
       description: "API for user feedback and future endpoints",
       defaultCorsPreflightOptions: {
         allowOrigins: [frontendUrl, "http://localhost:3000"],
-        allowMethods: ["POST", "OPTIONS"],
+        allowMethods: ["GET", "POST", "PUT", "OPTIONS"],
         allowHeaders: ["Content-Type", "Authorization"],
       },
       deployOptions: {
@@ -597,6 +642,11 @@ export class BackendConstruct extends Construct {
         cacheClusterEnabled: true,
         cacheClusterSize: "0.5",
         cacheTtl: cdk.Duration.minutes(5),
+        // The API Gateway cache does not vary on the Authorization header, so the
+        // per-user GET /mcp-servers response must never be cached (cross-user leak).
+        methodOptions: {
+          "/mcp-servers/GET": { cachingEnabled: false },
+        },
         loggingLevel: apigateway.MethodLoggingLevel.INFO,
         dataTraceEnabled: true,
         metricsEnabled: true,
@@ -634,6 +684,48 @@ export class BackendConstruct extends Construct {
       authorizationType: apigateway.AuthorizationType.COGNITO,
       requestValidator: requestValidator,
     })
+
+    // Per-user MCP server preferences: GET /mcp-servers (catalog + caller's toggles)
+    // and PUT /mcp-servers (save caller's enabled list). Same Cognito authorizer.
+    if (mcpPrefsTable) {
+      const mcpPrefsLambda = new PythonFunction(this, "McpPrefsLambda", {
+        functionName: `${config.stack_name_base}-mcp-prefs`,
+        runtime: lambda.Runtime.PYTHON_3_13,
+        architecture: lambda.Architecture.ARM_64,
+        entry: path.join(__dirname, "..", "lambdas", "mcp-prefs"), // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+        handler: "handler",
+        environment: {
+          TABLE_NAME: mcpPrefsTable.tableName,
+          MCP_SERVERS_CATALOG: this.mcpServersCatalogJson(config),
+          CORS_ALLOWED_ORIGINS: `${frontendUrl},http://localhost:3000`,
+        },
+        timeout: cdk.Duration.seconds(30),
+        layers: [
+          lambda.LayerVersion.fromLayerVersionArn(
+            this,
+            "McpPrefsPowertoolsLayer",
+            `arn:aws:lambda:${
+              cdk.Stack.of(this).region
+            }:017000801446:layer:AWSLambdaPowertoolsPythonV3-python313-arm64:18`
+          ),
+        ],
+        logGroup: new logs.LogGroup(this, "McpPrefsLambdaLogGroup", {
+          logGroupName: `/aws/lambda/${config.stack_name_base}-mcp-prefs`,
+          retention: logs.RetentionDays.ONE_WEEK,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+      })
+      mcpPrefsTable.grantReadWriteData(mcpPrefsLambda)
+
+      const mcpServersResource = api.root.addResource("mcp-servers")
+      const mcpPrefsIntegration = new apigateway.LambdaIntegration(mcpPrefsLambda)
+      for (const method of ["GET", "PUT"]) {
+        mcpServersResource.addMethod(method, mcpPrefsIntegration, {
+          authorizer,
+          authorizationType: apigateway.AuthorizationType.COGNITO,
+        })
+      }
+    }
 
     // Store the API URL for access from main stack
     this.feedbackApiUrl = api.url
@@ -856,6 +948,9 @@ export class BackendConstruct extends Construct {
     // Ensure proper creation order
     gateway.node.addDependency(this.machineClient)
     gateway.node.addDependency(gatewayRole)
+
+    // Attach additional MCP servers declared in config.yaml (backend.mcp_servers)
+    attachMcpServerTargets(this, config, gateway)
 
     // ========================================
     // Cedar Policy Engine + Policy via Custom Resource

--- a/infra-cdk/lib/utils/config-manager.ts
+++ b/infra-cdk/lib/utils/config-manager.ts
@@ -26,6 +26,44 @@ export interface VpcConfig {
   security_group_ids?: string[]
 }
 
+/**
+ * Authentication for an MCP-server gateway target.
+ * - NONE: public, unauthenticated upstream MCP (credential config omitted on the target).
+ * - OAUTH: OAuth2 Client Credentials (M2M) via an AgentCore Token Vault provider.
+ * IAM_SIGV4 / API_KEY are rejected at validation time — AgentCore Gateway does not
+ * support them on MCP-server targets. stdio servers (command/args) are also rejected;
+ * Gateway speaks streamable-HTTP MCP only.
+ */
+export type McpServerAuth =
+  | { type: "NONE" }
+  | {
+      type: "OAUTH"
+      /** OAuth2 client ID (plaintext). Provide this or client_id_secret_arn. */
+      client_id?: string
+      /** Secrets Manager ARN holding the client ID. Resolved by CloudFormation at deploy. */
+      client_id_secret_arn?: string
+      /** Secrets Manager ARN holding the client secret (never embedded in the template). */
+      client_secret_secret_arn: string
+      /** OIDC discovery URL of the OAuth2 authorization server. */
+      discovery_url: string
+      scopes?: string[]
+    }
+
+export interface McpServerConfig {
+  /** Stable identifier. Alphanumeric + hyphens (used in resource names). */
+  id: string
+  name: string
+  description?: string
+  /** HTTPS endpoint of the streamable-HTTP MCP server. */
+  endpoint: string
+  /** Set false to keep the entry in config without deploying it. Defaults to true. */
+  enabled?: boolean
+  /** Whether the server starts enabled for users who haven't set preferences. Defaults to true. */
+  default_enabled?: boolean
+  /** Defaults to { type: "NONE" }. */
+  auth?: McpServerAuth
+}
+
 export interface AppConfig {
   stack_name_base: string
   admin_user_email?: string | null
@@ -55,7 +93,57 @@ export interface AppConfig {
      * Maps to the relevance_score parameter of RetrievalConfig. Defaults to 0.3.
      */
     ltm_relevance_score: number
+    /** Catalog of additional MCP servers exposed through the AgentCore Gateway. */
+    mcp_servers?: McpServerConfig[]
   }
+}
+
+const MCP_SERVER_ID_PATTERN = /^[0-9a-zA-Z][0-9a-zA-Z-]*$/
+
+function validateMcpServers(servers: unknown, configPath: string): McpServerConfig[] | undefined {
+  if (servers === undefined || servers === null) return undefined
+  if (!Array.isArray(servers)) {
+    throw new Error(`backend.mcp_servers must be a list in ${configPath}`)
+  }
+  const seenIds = new Set<string>()
+  for (const s of servers as (McpServerConfig & { command?: string; args?: string[] })[]) {
+    const where = `backend.mcp_servers entry '${s?.id ?? "?"}' in ${configPath}`
+    if (s.command || s.args) {
+      throw new Error(
+        `${where}: stdio MCP servers (command/args) are not supported — AgentCore Gateway only supports streamable-HTTP MCP endpoints.`
+      )
+    }
+    if (!s.id || !MCP_SERVER_ID_PATTERN.test(s.id)) {
+      throw new Error(`${where}: id is required and must match ${MCP_SERVER_ID_PATTERN} (alphanumeric and hyphens).`)
+    }
+    if (seenIds.has(s.id)) {
+      throw new Error(`${where}: duplicate id.`)
+    }
+    seenIds.add(s.id)
+    if (!s.name) {
+      throw new Error(`${where}: name is required.`)
+    }
+    if (!s.endpoint || !s.endpoint.startsWith("https://")) {
+      throw new Error(`${where}: endpoint is required and must be an https:// URL.`)
+    }
+    const auth = s.auth ?? { type: "NONE" }
+    if (auth.type === "OAUTH") {
+      if (!auth.discovery_url) {
+        throw new Error(`${where}: auth.discovery_url is required for OAUTH.`)
+      }
+      if (!auth.client_secret_secret_arn?.startsWith("arn:aws:secretsmanager:")) {
+        throw new Error(`${where}: auth.client_secret_secret_arn must be a Secrets Manager ARN.`)
+      }
+      if (!auth.client_id === !auth.client_id_secret_arn) {
+        throw new Error(`${where}: provide exactly one of auth.client_id or auth.client_id_secret_arn.`)
+      }
+    } else if (auth.type !== "NONE") {
+      throw new Error(
+        `${where}: auth.type '${(auth as { type: string }).type}' is not supported on MCP-server targets. Use NONE or OAUTH.`
+      )
+    }
+  }
+  return servers as McpServerConfig[]
 }
 
 export class ConfigManager {
@@ -149,6 +237,7 @@ export class ConfigManager {
           use_long_term_memory: parsedConfig.backend?.use_long_term_memory === true,
           ltm_top_k: parsedConfig.backend?.ltm_top_k ?? 10,
           ltm_relevance_score: parsedConfig.backend?.ltm_relevance_score ?? 0.3,
+          mcp_servers: validateMcpServers(parsedConfig.backend?.mcp_servers, configPath),
         },
       }
     } catch (error) {

--- a/infra-cdk/lib/utils/mcp-servers.ts
+++ b/infra-cdk/lib/utils/mcp-servers.ts
@@ -1,0 +1,76 @@
+/**
+ * Wires `backend.mcp_servers` config entries from `config.yaml` into the
+ * AgentCore Gateway as additional MCP-server targets.
+ *
+ * Auth types (validated in config-manager.ts):
+ *   - NONE  — public upstream MCP. Passing an empty credential list makes the
+ *             L2 omit credentialProviderConfigurations from the template,
+ *             which is what the Gateway API requires for unauthenticated
+ *             MCP-server targets.
+ *   - OAUTH — OAuth2 Client Credentials (M2M). Uses the native
+ *             AWS::BedrockAgentCore::OAuth2CredentialProvider resource via
+ *             the L2 OAuth2CredentialProvider — no Custom Resource Lambda and
+ *             no extra IAM grants needed. Secret values are resolved by
+ *             CloudFormation dynamic references at deploy time, so they are
+ *             never embedded in the synthesized template.
+ */
+
+import * as cdk from "aws-cdk-lib"
+import * as agentcore from "aws-cdk-lib/aws-bedrockagentcore"
+import { Construct } from "constructs"
+
+import { AppConfig, McpServerConfig } from "./config-manager"
+
+/**
+ * Attach every enabled MCP server entry to the gateway.
+ */
+export function attachMcpServerTargets(
+  scope: Construct,
+  config: AppConfig,
+  gateway: agentcore.IGateway
+): agentcore.GatewayTarget[] {
+  const entries = (config.backend.mcp_servers ?? []).filter(s => s.enabled !== false)
+  return entries.map(entry =>
+    agentcore.GatewayTarget.forMcpServer(scope, `MCPTarget-${entry.id}`, {
+      gateway,
+      // Short name: gateway tool names become "{target}___{tool}" and must stay
+      // within Bedrock's 64-char tool-name limit, so no stack prefix here
+      // (the gateway is already stack-scoped).
+      gatewayTargetName: `mcp-${entry.id}`,
+      description: entry.description ?? entry.name,
+      endpoint: entry.endpoint,
+      credentialProviderConfigurations: buildCredentialProviders(scope, entry, config),
+    })
+  )
+}
+
+function buildCredentialProviders(
+  scope: Construct,
+  entry: McpServerConfig,
+  config: AppConfig
+): agentcore.ICredentialProviderConfig[] {
+  const auth = entry.auth ?? { type: "NONE" }
+  if (auth.type === "NONE") return []
+
+  // client_id may be given inline or as a Secrets Manager ARN; either way it
+  // reaches CloudFormation as a string (dynamic reference in the ARN case).
+  const clientId =
+    auth.client_id ?? cdk.SecretValue.secretsManager(auth.client_id_secret_arn!).unsafeUnwrap()
+
+  const provider = agentcore.OAuth2CredentialProvider.usingCustom(
+    scope,
+    `MCPOAuthProvider-${entry.id}`,
+    {
+      oAuth2CredentialProviderName: `${config.stack_name_base}-mcp-${entry.id}-oauth`,
+      clientId,
+      clientSecret: cdk.SecretValue.secretsManager(auth.client_secret_secret_arn),
+      discoveryUrl: auth.discovery_url,
+    }
+  )
+
+  return [
+    agentcore.GatewayCredentialProvider.fromOauthIdentity(provider, {
+      scopes: auth.scopes ?? [],
+    }),
+  ]
+}

--- a/infra-terraform/main.tf
+++ b/infra-terraform/main.tf
@@ -90,6 +90,9 @@ module "backend" {
   # Frontend URL for CORS
   frontend_url = module.amplify_hosting.app_url
 
+  # Additional MCP servers exposed through the AgentCore Gateway
+  mcp_servers = var.mcp_servers
+
   # Optional overrides
   log_retention_days     = local.log_retention_days
   throttling_rate_limit  = local.api_throttling_rate_limit

--- a/infra-terraform/modules/backend/feedback.tf
+++ b/infra-terraform/modules/backend/feedback.tf
@@ -324,6 +324,12 @@ resource "aws_api_gateway_deployment" "feedback" {
       aws_api_gateway_method.options_feedback.id,
       aws_api_gateway_integration.post_feedback.id,
       aws_api_gateway_integration.options_feedback.id,
+      # /mcp-servers routes (empty when no MCP servers configured)
+      [for r in aws_api_gateway_resource.mcp_servers : r.id],
+      [for m in values(aws_api_gateway_method.mcp_servers) : m.id],
+      [for i in values(aws_api_gateway_integration.mcp_servers) : i.id],
+      [for m in aws_api_gateway_method.options_mcp_servers : m.id],
+      [for i in aws_api_gateway_integration.options_mcp_servers : i.id],
     ]))
   }
 
@@ -333,7 +339,9 @@ resource "aws_api_gateway_deployment" "feedback" {
 
   depends_on = [
     aws_api_gateway_integration.post_feedback,
-    aws_api_gateway_integration.options_feedback
+    aws_api_gateway_integration.options_feedback,
+    aws_api_gateway_integration.mcp_servers,
+    aws_api_gateway_integration.options_mcp_servers
   ]
 }
 

--- a/infra-terraform/modules/backend/mcp_servers.tf
+++ b/infra-terraform/modules/backend/mcp_servers.tf
@@ -1,0 +1,345 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# =============================================================================
+# Dynamic MCP Servers
+# Maps to: infra-cdk/lib/utils/mcp-servers.ts + McpPrefsTable/McpPrefsLambda in
+# backend-construct.ts
+#
+# - Each enabled entry in var.mcp_servers becomes an AgentCore Gateway target
+#   named "{stack_name_base}-mcp-{id}" (streamable-HTTP MCP endpoint).
+# - OAUTH entries get a native OAuth2 credential provider; secrets are read
+#   from Secrets Manager at plan time and never appear in state outputs.
+# - Per-user preferences: DynamoDB table + mcp-prefs Lambda on the feedback
+#   API Gateway (GET/PUT /mcp-servers, same Cognito authorizer). The agent
+#   runtime filters gateway tools per user (see patterns/*/tools/mcp_prefs.py).
+# =============================================================================
+
+locals {
+  mcp_servers_enabled = [for s in var.mcp_servers : s if s.enabled]
+  mcp_servers_by_id   = { for s in local.mcp_servers_enabled : s.id => s }
+  mcp_oauth_servers   = { for s in local.mcp_servers_enabled : s.id => s if try(s.auth.type, "NONE") == "OAUTH" }
+  mcp_feature_enabled = length(local.mcp_servers_enabled) > 0
+
+  # Deploy-time catalog shared by the prefs Lambda and the agent runtime.
+  # Contains no secrets.
+  mcp_servers_catalog = jsonencode([
+    for s in local.mcp_servers_enabled : {
+      id              = s.id
+      name            = s.name
+      description     = coalesce(s.description, "")
+      default_enabled = s.default_enabled
+    }
+  ])
+
+  # Reuses the CDK Lambda source (same pattern as the feedback Lambda).
+  mcp_prefs_lambda_source_path = "${path.module}/../../../infra-cdk/lambdas/mcp-prefs"
+}
+
+# -----------------------------------------------------------------------------
+# OAuth2 credential providers (OAUTH entries only)
+# -----------------------------------------------------------------------------
+
+data "aws_secretsmanager_secret_version" "mcp_oauth_client_secret" {
+  for_each  = local.mcp_oauth_servers
+  secret_id = each.value.auth.client_secret_secret_arn
+}
+
+data "aws_secretsmanager_secret_version" "mcp_oauth_client_id" {
+  for_each  = { for id, s in local.mcp_oauth_servers : id => s if try(s.auth.client_id_secret_arn, null) != null }
+  secret_id = each.value.auth.client_id_secret_arn
+}
+
+resource "aws_bedrockagentcore_oauth2_credential_provider" "mcp" {
+  for_each = local.mcp_oauth_servers
+
+  name                       = "${var.stack_name_base}-mcp-${each.key}-oauth"
+  credential_provider_vendor = "CustomOauth2"
+
+  oauth2_provider_config {
+    custom_oauth2_provider_config {
+      client_id = (
+        try(each.value.auth.client_id, null) != null
+        ? each.value.auth.client_id
+        : data.aws_secretsmanager_secret_version.mcp_oauth_client_id[each.key].secret_string
+      )
+      client_secret = data.aws_secretsmanager_secret_version.mcp_oauth_client_secret[each.key].secret_string
+
+      oauth_discovery {
+        discovery_url = each.value.auth.discovery_url
+      }
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Gateway targets
+# -----------------------------------------------------------------------------
+
+resource "aws_bedrockagentcore_gateway_target" "mcp" {
+  for_each = local.mcp_servers_by_id
+
+  # Short name: gateway tool names become "{target}___{tool}" and must stay
+  # within Bedrock's 64-char tool-name limit, so no stack prefix here
+  # (the gateway is already stack-scoped).
+  name               = "mcp-${each.key}"
+  gateway_identifier = aws_bedrockagentcore_gateway.main.gateway_id
+  description        = coalesce(each.value.description, each.value.name)
+
+  # NONE auth: the block is omitted entirely — the Gateway API rejects any
+  # credential provider type on unauthenticated MCP-server targets.
+  dynamic "credential_provider_configuration" {
+    for_each = try(each.value.auth.type, "NONE") == "OAUTH" ? [1] : []
+    content {
+      oauth {
+        provider_arn = aws_bedrockagentcore_oauth2_credential_provider.mcp[each.key].credential_provider_arn
+        scopes       = try(each.value.auth.scopes, [])
+      }
+    }
+  }
+
+  target_configuration {
+    mcp {
+      mcp_server {
+        endpoint = each.value.endpoint
+      }
+    }
+  }
+
+  depends_on = [aws_bedrockagentcore_gateway.main]
+}
+
+# -----------------------------------------------------------------------------
+# Per-user preferences: DynamoDB table
+# -----------------------------------------------------------------------------
+
+resource "aws_dynamodb_table" "mcp_prefs" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  name         = "${var.stack_name_base}-mcp-prefs"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "userId"
+
+  attribute {
+    name = "userId"
+    type = "S"
+  }
+
+  deletion_protection_enabled = false
+
+  server_side_encryption {
+    enabled = true
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Preferences Lambda (GET/PUT /mcp-servers)
+# -----------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "mcp_prefs_lambda" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  name              = "/aws/lambda/${var.stack_name_base}-mcp-prefs"
+  retention_in_days = local.log_retention_days
+}
+
+data "aws_iam_policy_document" "mcp_prefs_lambda_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "mcp_prefs_lambda" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  name               = "${var.stack_name_base}-mcp-prefs-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.mcp_prefs_lambda_assume_role.json
+  description        = "Execution role for MCP preferences Lambda function"
+}
+
+data "aws_iam_policy_document" "mcp_prefs_lambda_policy" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = ["${aws_cloudwatch_log_group.mcp_prefs_lambda[0].arn}:*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem"
+    ]
+    resources = [aws_dynamodb_table.mcp_prefs[0].arn]
+  }
+}
+
+resource "aws_iam_role_policy" "mcp_prefs_lambda" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  name   = "${var.stack_name_base}-mcp-prefs-lambda-policy"
+  role   = aws_iam_role.mcp_prefs_lambda[0].id
+  policy = data.aws_iam_policy_document.mcp_prefs_lambda_policy[0].json
+}
+
+# No pip build needed — the Lambda has no dependencies beyond the Powertools
+# layer and the runtime's boto3, so the source dir is zipped directly.
+data "archive_file" "mcp_prefs_lambda" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  type        = "zip"
+  source_dir  = local.mcp_prefs_lambda_source_path
+  output_path = "${path.module}/artifacts/mcp_prefs_lambda.zip"
+  excludes    = ["__pycache__", "*.pyc"]
+}
+
+resource "aws_lambda_function" "mcp_prefs" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  function_name = "${var.stack_name_base}-mcp-prefs"
+  role          = aws_iam_role.mcp_prefs_lambda[0].arn
+  handler       = "index.handler"
+  runtime       = "python3.13"
+  timeout       = 30
+  memory_size   = 256
+
+  filename         = data.archive_file.mcp_prefs_lambda[0].output_path
+  source_code_hash = data.archive_file.mcp_prefs_lambda[0].output_base64sha256
+
+  layers = [local.powertools_layer_arn]
+
+  environment {
+    variables = {
+      TABLE_NAME           = aws_dynamodb_table.mcp_prefs[0].name
+      MCP_SERVERS_CATALOG  = local.mcp_servers_catalog
+      CORS_ALLOWED_ORIGINS = "${var.frontend_url},http://localhost:3000"
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.mcp_prefs_lambda]
+}
+
+resource "aws_lambda_permission" "mcp_prefs_api_gateway" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.mcp_prefs[0].function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.feedback.execution_arn}/*/*"
+}
+
+# -----------------------------------------------------------------------------
+# API Gateway routes: /mcp-servers (GET, PUT, OPTIONS) on the feedback API
+# -----------------------------------------------------------------------------
+
+resource "aws_api_gateway_resource" "mcp_servers" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  rest_api_id = aws_api_gateway_rest_api.feedback.id
+  parent_id   = aws_api_gateway_rest_api.feedback.root_resource_id
+  path_part   = "mcp-servers"
+}
+
+resource "aws_api_gateway_method" "mcp_servers" {
+  for_each = local.mcp_feature_enabled ? toset(["GET", "PUT"]) : toset([])
+
+  rest_api_id   = aws_api_gateway_rest_api.feedback.id
+  resource_id   = aws_api_gateway_resource.mcp_servers[0].id
+  http_method   = each.value
+  authorization = "COGNITO_USER_POOLS"
+  authorizer_id = aws_api_gateway_authorizer.cognito.id
+}
+
+resource "aws_api_gateway_integration" "mcp_servers" {
+  for_each = local.mcp_feature_enabled ? toset(["GET", "PUT"]) : toset([])
+
+  rest_api_id             = aws_api_gateway_rest_api.feedback.id
+  resource_id             = aws_api_gateway_resource.mcp_servers[0].id
+  http_method             = aws_api_gateway_method.mcp_servers[each.value].http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.mcp_prefs[0].invoke_arn
+}
+
+# OPTIONS /mcp-servers (CORS preflight)
+resource "aws_api_gateway_method" "options_mcp_servers" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  rest_api_id   = aws_api_gateway_rest_api.feedback.id
+  resource_id   = aws_api_gateway_resource.mcp_servers[0].id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "options_mcp_servers" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  rest_api_id = aws_api_gateway_rest_api.feedback.id
+  resource_id = aws_api_gateway_resource.mcp_servers[0].id
+  http_method = aws_api_gateway_method.options_mcp_servers[0].http_method
+  type        = "MOCK"
+
+  request_templates = {
+    "application/json" = jsonencode({
+      statusCode = 200
+    })
+  }
+}
+
+resource "aws_api_gateway_method_response" "options_mcp_servers" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  rest_api_id = aws_api_gateway_rest_api.feedback.id
+  resource_id = aws_api_gateway_resource.mcp_servers[0].id
+  http_method = aws_api_gateway_method.options_mcp_servers[0].http_method
+  status_code = "200"
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true
+    "method.response.header.Access-Control-Allow-Methods" = true
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+}
+
+resource "aws_api_gateway_integration_response" "options_mcp_servers" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  rest_api_id = aws_api_gateway_rest_api.feedback.id
+  resource_id = aws_api_gateway_resource.mcp_servers[0].id
+  http_method = aws_api_gateway_method.options_mcp_servers[0].http_method
+  status_code = aws_api_gateway_method_response.options_mcp_servers[0].status_code
+
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'"
+    "method.response.header.Access-Control-Allow-Methods" = "'GET,PUT,OPTIONS'"
+    "method.response.header.Access-Control-Allow-Origin"  = "'${var.frontend_url}'"
+  }
+
+  depends_on = [aws_api_gateway_integration.options_mcp_servers]
+}
+
+# The API Gateway cache does not vary on the Authorization header, so the
+# per-user GET /mcp-servers response must never be cached (cross-user leak).
+resource "aws_api_gateway_method_settings" "mcp_servers_get" {
+  count = local.mcp_feature_enabled ? 1 : 0
+
+  rest_api_id = aws_api_gateway_rest_api.feedback.id
+  stage_name  = aws_api_gateway_stage.prod.stage_name
+  method_path = "mcp-servers/GET"
+
+  settings {
+    caching_enabled = false
+  }
+}

--- a/infra-terraform/modules/backend/runtime.tf
+++ b/infra-terraform/modules/backend/runtime.tf
@@ -345,6 +345,17 @@ data "aws_iam_policy_document" "runtime_policy" {
       "arn:aws:bedrock-agentcore:${local.region}:${local.account_id}:workload-identity-directory/*"
     ]
   }
+
+  # Per-user MCP preferences lookup (only when MCP servers are configured)
+  dynamic "statement" {
+    for_each = local.mcp_feature_enabled ? [1] : []
+    content {
+      sid       = "McpPrefsTableRead"
+      effect    = "Allow"
+      actions   = ["dynamodb:GetItem"]
+      resources = [aws_dynamodb_table.mcp_prefs[0].arn]
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "runtime" {
@@ -480,7 +491,13 @@ resource "aws_bedrockagentcore_agent_runtime" "main" {
       GATEWAY_CREDENTIAL_PROVIDER_NAME = "${var.stack_name_base}-runtime-gateway-auth"
     },
     # claude-agent-sdk patterns require CLAUDE_CODE_USE_BEDROCK=1
-    local.is_claude_agent_sdk ? { CLAUDE_CODE_USE_BEDROCK = "1" } : {}
+    local.is_claude_agent_sdk ? { CLAUDE_CODE_USE_BEDROCK = "1" } : {},
+    # Per-user MCP server preferences: the agent reads the caller's enabled list
+    # from DynamoDB and filters gateway tools (see patterns/*/tools/mcp_prefs.py)
+    local.mcp_feature_enabled ? {
+      MCP_PREFS_TABLE     = aws_dynamodb_table.mcp_prefs[0].name
+      MCP_SERVERS_CATALOG = local.mcp_servers_catalog
+    } : {}
   )
 
   # Force runtime replacement when agent code changes (zip or docker)

--- a/infra-terraform/modules/backend/variables.tf
+++ b/infra-terraform/modules/backend/variables.tf
@@ -112,3 +112,61 @@ variable "throttling_burst_limit" {
   default     = 200
 }
 
+# =============================================================================
+# MCP Servers (additional AgentCore Gateway targets)
+# =============================================================================
+
+variable "mcp_servers" {
+  description = <<-EOT
+    Catalog of additional MCP servers exposed to the agent through the AgentCore
+    Gateway. Only streamable-HTTP endpoints are supported (no stdio command/args).
+    auth.type: NONE (default) or OAUTH (client-credentials via Secrets Manager).
+  EOT
+  type = list(object({
+    id              = string
+    name            = string
+    description     = optional(string)
+    endpoint        = string
+    enabled         = optional(bool, true)
+    default_enabled = optional(bool, true)
+    auth = optional(object({
+      type                     = string
+      client_id                = optional(string)
+      client_id_secret_arn     = optional(string)
+      client_secret_secret_arn = optional(string)
+      discovery_url            = optional(string)
+      scopes                   = optional(list(string), [])
+    }))
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for s in var.mcp_servers : can(regex("^[0-9a-zA-Z][0-9a-zA-Z-]*$", s.id))])
+    error_message = "mcp_servers[*].id must be alphanumeric with hyphens."
+  }
+  validation {
+    condition     = length(distinct([for s in var.mcp_servers : s.id])) == length(var.mcp_servers)
+    error_message = "mcp_servers[*].id must be unique."
+  }
+  validation {
+    condition     = alltrue([for s in var.mcp_servers : startswith(s.endpoint, "https://")])
+    error_message = "mcp_servers[*].endpoint must be an https:// URL."
+  }
+  validation {
+    condition     = alltrue([for s in var.mcp_servers : contains(["NONE", "OAUTH"], try(s.auth.type, "NONE"))])
+    error_message = "mcp_servers[*].auth.type must be NONE or OAUTH (IAM_SIGV4/API_KEY are not supported on MCP-server targets)."
+  }
+  validation {
+    condition = alltrue([
+      for s in var.mcp_servers : (
+        try(s.auth.type, "NONE") != "OAUTH" || (
+          try(s.auth.discovery_url, null) != null &&
+          try(s.auth.client_secret_secret_arn, null) != null &&
+          ((try(s.auth.client_id, null) != null) != (try(s.auth.client_id_secret_arn, null) != null))
+        )
+      )
+    ])
+    error_message = "OAUTH entries need discovery_url, client_secret_secret_arn, and exactly one of client_id / client_id_secret_arn."
+  }
+}
+

--- a/infra-terraform/terraform.tfvars.example
+++ b/infra-terraform/terraform.tfvars.example
@@ -62,3 +62,30 @@ backend_network_mode = "PUBLIC"
 # backend_vpc_id                 = "vpc-xxxxxxxxxxxxxxxxx"
 # backend_vpc_subnet_ids         = ["subnet-xxxxxxxxxxxxxxxxx", "subnet-yyyyyyyyyyyyyyyyy"]
 # backend_vpc_security_group_ids = ["sg-xxxxxxxxxxxxxxxxx"]  # Optional
+
+# -----------------------------------------------------------------------------
+# Additional MCP servers exposed to the agent through the AgentCore Gateway.
+# Only streamable-HTTP endpoints are supported (no stdio command/args).
+# auth.type: NONE (default) or OAUTH (client-credentials via Secrets Manager).
+# -----------------------------------------------------------------------------
+# mcp_servers = [
+#   {
+#     id          = "aws-knowledge"
+#     name        = "AWS Knowledge"
+#     description = "Up-to-date AWS docs, API references, and blog content."
+#     endpoint    = "https://knowledge-mcp.global.api.aws"
+#   },
+#   {
+#     id              = "my-oauth-mcp"
+#     name            = "My OAuth MCP"
+#     endpoint        = "https://secure-mcp.example.com/mcp"
+#     default_enabled = false # initial on/off state for users who haven't set preferences
+#     auth = {
+#       type                     = "OAUTH"
+#       client_id                = "my-client-id" # or client_id_secret_arn
+#       client_secret_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-mcp-secret-AbCdEf"
+#       discovery_url            = "https://auth.example.com/.well-known/openid-configuration"
+#       scopes                   = ["mcp/invoke"]
+#     }
+#   },
+# ]

--- a/infra-terraform/variables.tf
+++ b/infra-terraform/variables.tf
@@ -89,3 +89,33 @@ variable "backend_vpc_security_group_ids" {
   default     = []
 }
 
+
+# =============================================================================
+# MCP Servers (additional AgentCore Gateway targets)
+# =============================================================================
+# Validation lives on the backend module's variable of the same name.
+
+variable "mcp_servers" {
+  description = <<-EOT
+    Catalog of additional MCP servers exposed to the agent through the AgentCore
+    Gateway. Only streamable-HTTP endpoints are supported (no stdio command/args).
+    auth.type: NONE (default) or OAUTH (client-credentials via Secrets Manager).
+  EOT
+  type = list(object({
+    id              = string
+    name            = string
+    description     = optional(string)
+    endpoint        = string
+    enabled         = optional(bool, true)
+    default_enabled = optional(bool, true)
+    auth = optional(object({
+      type                     = string
+      client_id                = optional(string)
+      client_id_secret_arn     = optional(string)
+      client_secret_secret_arn = optional(string)
+      discovery_url            = optional(string)
+      scopes                   = optional(list(string), [])
+    }))
+  }))
+  default = []
+}

--- a/patterns/strands-single-agent/tools/gateway.py
+++ b/patterns/strands-single-agent/tools/gateway.py
@@ -28,6 +28,7 @@ import os
 
 from mcp.client.streamable_http import streamablehttp_client
 from strands.tools.mcp import MCPClient
+from tools.mcp_prefs import build_gateway_tool_filters
 from utils.auth import get_gateway_access_token
 from utils.ssm import get_ssm_parameter
 
@@ -66,6 +67,9 @@ def create_gateway_mcp_client(user_id: str) -> MCPClient:
             headers={"Authorization": f"Bearer {get_gateway_access_token(user_id)}"},
         ),
         prefix="gateway",
+        # Hide tools from MCP servers this user has disabled in settings
+        # (per-user preferences from DynamoDB; None when nothing to filter).
+        tool_filters=build_gateway_tool_filters(user_id),
     )
 
 

--- a/patterns/strands-single-agent/tools/gateway.py
+++ b/patterns/strands-single-agent/tools/gateway.py
@@ -28,9 +28,10 @@ import os
 
 from mcp.client.streamable_http import streamablehttp_client
 from strands.tools.mcp import MCPClient
-from tools.mcp_prefs import build_gateway_tool_filters
 from utils.auth import get_gateway_access_token
 from utils.ssm import get_ssm_parameter
+
+from tools.mcp_prefs import build_gateway_tool_filters
 
 logger = logging.getLogger(__name__)
 

--- a/patterns/strands-single-agent/tools/mcp_prefs.py
+++ b/patterns/strands-single-agent/tools/mcp_prefs.py
@@ -1,0 +1,77 @@
+"""Per-user MCP server tool filtering.
+
+The CDK stack attaches every configured MCP server to the AgentCore Gateway as
+a target named ``mcp-{server_id}``, and the Gateway exposes each
+upstream tool as ``{target_name}___{tool_name}``. This module reads the calling
+user's enabled-servers preference from DynamoDB (written by the /mcp-servers
+API) and produces a Strands ``tool_filters`` rejection callback that hides
+tools belonging to servers the user has disabled.
+
+Environment (set by CDK only when backend.mcp_servers is configured):
+    MCP_PREFS_TABLE      — DynamoDB table keyed by userId
+    MCP_SERVERS_CATALOG  — JSON list of {id, name, description, default_enabled}
+
+Fail-open by design: on any error (table unreachable, malformed item) the
+filter falls back to the catalog's default-enabled set so the agent keeps
+responding instead of failing the request.
+"""
+
+import json
+import logging
+import os
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+
+def _catalog() -> list[dict]:
+    return json.loads(os.environ.get("MCP_SERVERS_CATALOG", "[]"))
+
+
+def _default_enabled_ids(catalog: list[dict]) -> set[str]:
+    return {s["id"] for s in catalog if s.get("default_enabled", True)}
+
+
+def get_disabled_server_ids(user_id: str) -> set[str]:
+    """Ids of catalog MCP servers the user has disabled (empty when feature off)."""
+    catalog = _catalog()
+    if not catalog:
+        return set()
+
+    all_ids = {s["id"] for s in catalog}
+    table_name = os.environ.get("MCP_PREFS_TABLE")
+    enabled = _default_enabled_ids(catalog)
+    if table_name:
+        try:
+            table = boto3.resource("dynamodb").Table(table_name)
+            item = table.get_item(Key={"userId": user_id}).get("Item")
+            if item is not None:
+                # Catalog is authoritative: prefs for removed servers are ignored.
+                enabled = set(item.get("enabled", [])) & all_ids
+        except Exception:
+            logger.exception("Failed to read MCP preferences; using catalog defaults")
+
+    disabled = all_ids - enabled
+    if disabled:
+        logger.info("[MCP] Disabled servers for user: %s", sorted(disabled))
+    return disabled
+
+
+def build_gateway_tool_filters(user_id: str) -> dict | None:
+    """Strands ToolFilters rejecting tools from servers the user disabled.
+
+    Returns None when nothing needs filtering so MCPClient takes its fast path.
+    """
+    disabled = get_disabled_server_ids(user_id)
+    if not disabled:
+        return None
+
+    # Gateway tool names contain "mcp-{id}___"; match on that marker so
+    # the check is unaffected by any client-side prefix Strands adds.
+    markers = [f"mcp-{server_id}___" for server_id in disabled]
+
+    def _rejected(tool, **_kwargs) -> bool:
+        return any(marker in tool.tool_name for marker in markers)
+
+    return {"rejected": [_rejected]}


### PR DESCRIPTION
## Summary

- Developers declare MCP servers in `config.yaml` / `terraform.tfvars` — each becomes an AgentCore Gateway target (streamable-HTTP MCP, NONE or OAUTH auth)
- Per-user enable/disable via settings dialog (gear icon in chat header); preferences persisted in DynamoDB across sessions/devices
- Agent runtime filters gateway tools per user on each request using Strands `tool_filters`; fail-open on DynamoDB error
- Full CDK + Terraform parity (types, validation, gateway targets, OAuth2 providers, prefs table, API routes, runtime env/IAM)
- Cedar policy opened to all gateway actions (tool names unknown at deploy time; per-user gating is runtime-side)
- Cedar-policy Lambda made idempotent (handles `ConflictException` on retry)
- Gateway target names shortened to `mcp-{id}` (Bedrock 64-char tool-name limit)

## Test plan

- [x] `tsc --noEmit` (CDK + frontend)
- [x] `cdk synth` — MCP targets, OAuth2 provider, prefs table, API routes all render correctly
- [x] `terraform validate` — passes
- [x] Python compile check (mcp-prefs Lambda, cedar-policy Lambda, mcp_prefs.py)
- [x] `mcp_prefs.py` logic self-check (defaults, prefs override, DDB error fail-open, filter callback)
- [x] Live deploy to us-west-2 — stack CREATE_COMPLETE, both targets READY
- [x] E2E preferences API (GET defaults, PUT, GET after toggle, 400 on bad body, 401 without token)
- [x] Agent tool list changes per user's enabled servers (verified both directions)
- [x] Real MCP tool call through gateway (aws-knowledge `search_documentation` → real URL returned)
- [x] Frontend deployed to Amplify — settings dialog renders, saves, persists
- [x] UI walkthrough: fresh user defaults, toggle, save, verify agent uses new tool set
- [x] Second user: confirm independent toggle state